### PR TITLE
feat: add finance hooks with zod validation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,8 @@
         "recharts": "^3.1.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
@@ -6558,6 +6559,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "recharts": "^3.1.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/src/hooks/useCreditCards.ts
+++ b/src/hooks/useCreditCards.ts
@@ -1,15 +1,6 @@
-import { useEffect, useState, useCallback } from "react";
-import { supabase } from "@/lib/supabaseClient";
-
-export type CreditCard = {
-  id: string;
-  name: string;
-  bank: string | null;
-  limit_amount: number | null;
-  cut_day: number | null;
-  due_day: number | null;
-  account_id: string | null;
-};
+import { useEffect, useState, useCallback } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+import { CreditCard, CreditCardSchema } from '@/types/finance';
 
 export function useCreditCards() {
   const [data, setData] = useState<CreditCard[]>([]);
@@ -18,15 +9,51 @@ export function useCreditCards() {
   const list = useCallback(async () => {
     setLoading(true);
     const { data, error } = await supabase
-      .from("credit_cards")
-      .select("id,name,bank,limit_amount,cut_day,due_day,account_id")
-      .order("name", { ascending: true });
+      .from('credit_cards')
+      .select('*')
+      .order('name', { ascending: true });
     if (error) throw error;
     setData(data as CreditCard[]);
     setLoading(false);
   }, []);
 
-  useEffect(() => { list(); }, [list]);
+  useEffect(() => {
+    void list();
+  }, [list]);
 
-  return { data, loading, list };
+  const add = async (payload: Omit<CreditCard, 'id' | 'user_id'>) => {
+    const parsed = CreditCardSchema.omit({ id: true, user_id: true }).parse(payload);
+    const { data, error } = await supabase
+      .from('credit_cards')
+      .insert(parsed)
+      .select()
+      .single();
+    if (error) throw error;
+    setData((d) => [...d, data as CreditCard]);
+  };
+
+  const update = async (
+    id: string,
+    patch: Partial<Omit<CreditCard, 'id' | 'user_id'>>,
+  ) => {
+    const parsed = CreditCardSchema.omit({ id: true, user_id: true })
+      .partial()
+      .parse(patch);
+    const { data, error } = await supabase
+      .from('credit_cards')
+      .update(parsed)
+      .eq('id', id)
+      .select()
+      .single();
+    if (error) throw error;
+    setData((d) => d.map((c) => (c.id === id ? (data as CreditCard) : c)));
+  };
+
+  const remove = async (id: string) => {
+    const { error } = await supabase.from('credit_cards').delete().eq('id', id);
+    if (error) throw error;
+    setData((d) => d.filter((c) => c.id !== id));
+  };
+
+  return { data, loading, list, add, update, remove };
 }

--- a/src/types/finance.ts
+++ b/src/types/finance.ts
@@ -1,0 +1,54 @@
+import { z } from 'zod';
+
+export const AccountSchema = z.object({
+  id: z.string().uuid().optional(),
+  user_id: z.string().uuid().optional(),
+  name: z.string(),
+  type: z.enum(['conta', 'carteira', 'poupanca']),
+  institution: z.string().nullable(),
+  currency: z.string().nullable(),
+});
+export type Account = z.infer<typeof AccountSchema>;
+
+export const CreditCardSchema = z.object({
+  id: z.string().uuid().optional(),
+  user_id: z.string().uuid().optional(),
+  name: z.string(),
+  bank: z.string().nullable(),
+  limit_amount: z.number().nullable(),
+  cut_day: z.number().int().nullable(),
+  due_day: z.number().int().nullable(),
+  account_id: z.string().uuid(),
+});
+export type CreditCard = z.infer<typeof CreditCardSchema>;
+
+export const CategorySchema = z.object({
+  id: z.string().uuid().optional(),
+  user_id: z.string().uuid().optional(),
+  name: z.string(),
+  parent_id: z.string().uuid().nullable(),
+  kind: z.enum(['expense', 'income', 'transfer']),
+  color: z.string().nullable(),
+  icon_key: z.string().nullable(),
+});
+export type Category = z.infer<typeof CategorySchema>;
+
+export const TransactionSchema = z.object({
+  id: z.number().optional(),
+  user_id: z.string().uuid().optional(),
+  date: z.string(),
+  description: z.string(),
+  amount: z.number(),
+  category_id: z.string().uuid().nullable(),
+  source_type: z.enum(['account', 'card']),
+  source_id: z.string().uuid(),
+  installment_no: z.number().int().nullable(),
+  installments_total: z.number().int().nullable(),
+  parent_installment_id: z.number().nullable(),
+  attachment_url: z.string().url().nullable(),
+});
+export type Transaction = z.infer<typeof TransactionSchema>;
+
+export const TransactionInputSchema = TransactionSchema.omit({ id: true, parent_installment_id: true, attachment_url: true });
+export type TransactionInput = z.infer<typeof TransactionInputSchema>;
+


### PR DESCRIPTION
## Summary
- add strong types for accounts, cards, categories and transactions using Zod
- implement CRUD hooks for accounts, credit cards and categories
- enhance transactions hook with period filters, installment handling and attachment uploads

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 89 errors, 9 warnings)*
- `npm run build` *(fails: TS2339: Property 'type' does not exist on type ...)*

------
https://chatgpt.com/codex/tasks/task_e_6897bbe0f35c8322b53dc7b091e4b77e