### PR TITLE
feat: enhance transaction modal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,8 @@
         "recharts": "^3.1.2",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.3.1",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zod": "^3.25.76"
       },
       "devDependencies": {
         "@eslint/js": "^9.32.0",
@@ -6558,6 +6559,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.76",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
+      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
     "recharts": "^3.1.2",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.3.1",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@eslint/js": "^9.32.0",

--- a/src/components/ModalTransacao.tsx
+++ b/src/components/ModalTransacao.tsx
@@ -1,231 +1,345 @@
 import { useEffect, useState } from 'react';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { z } from 'zod';
+import { toast } from 'sonner';
+import { motion } from 'framer-motion';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+  DialogPortal,
+  DialogOverlay,
+} from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
+import MoneyInput from './MoneyInput';
+import SourcePicker from './SourcePicker';
+import { useAccounts } from '@/hooks/useAccounts';
+import { useCategories } from '@/hooks/useCategories';
 
-// \-\-\- Types -----------------------------------------------------------------
-export type BaseData = {
-  date: string;            // YYYY-MM-DD
+export type FormData = {
+  date: string;
   description: string;
-  value: number;           // sempre positivo; tipo define sinal
-  type: 'income' | 'expense';
-  category: string;        // (por enquanto texto; depois trocamos por category_id)
-  payment_method?: string; // Pix/Cartão/Dinheiro/Boleto/Transferência/Outro
-  // Extensões (opcionais, para o futuro sem quebrar quem usa hoje)
-  source_kind?: 'account' | 'card';
-  source_label?: string | null;  // nome da conta/cartão (placeholder até ligarmos ao banco)
-  installments?: number | null;  // número de parcelas, se cartão
-  notes?: string | null;
-  // Anexo (nota/recibo)
-  attachment_file?: File | null;
+  amount: number;
+  type: 'income' | 'expense' | 'transfer';
+  category_parent: string | null;
+  category_id: string | null;
+  source: { kind: 'account' | 'card'; id: string | null };
+  installments: number;
+  notes: string;
+  attachment_file: File | null;
+  from_account_id: string | null;
+  to_account_id: string | null;
 };
 
-export type Props = {
+type Props = {
   open: boolean;
   onClose: () => void;
-  initialData?: BaseData | null;
-  onSubmit: (data: BaseData) => Promise<void> | void;
+  initialData?: Partial<FormData> | null;
+  onSubmit: (data: any) => Promise<void> | void;
 };
 
-const CATEGORIAS = ['Alimentação','Transporte','Moradia','Educação','Saúde','Lazer','Salário','Freelance','Investimentos','Outros'];
-const METODOS = ['Pix','Cartão','Dinheiro','Boleto','Transferência','Outro'];
+const defaultForm: FormData = {
+  date: new Date().toISOString().slice(0, 10),
+  description: '',
+  amount: 0,
+  type: 'expense',
+  category_parent: null,
+  category_id: null,
+  source: { kind: 'account', id: null },
+  installments: 1,
+  notes: '',
+  attachment_file: null,
+  from_account_id: null,
+  to_account_id: null,
+};
+
+const schema = z
+  .object({
+    date: z.string().min(1, 'Informe a data'),
+    description: z.string().min(1, 'Informe a descrição'),
+    amount: z.number().positive('Informe um valor válido'),
+    type: z.enum(['income', 'expense', 'transfer']),
+    category_parent: z.string().nullable(),
+    category_id: z.string().nullable(),
+    source: z.object({ kind: z.enum(['account', 'card']), id: z.string().nullable() }),
+    installments: z.number().int().min(1).max(24),
+    notes: z.string().optional(),
+    attachment_file: z.any().nullable(),
+    from_account_id: z.string().nullable(),
+    to_account_id: z.string().nullable(),
+  })
+  .superRefine((d, ctx) => {
+    if (d.type === 'transfer') {
+      if (!d.from_account_id) ctx.addIssue({ code: 'custom', path: ['from_account_id'], message: 'Selecione a conta de origem' });
+      if (!d.to_account_id) ctx.addIssue({ code: 'custom', path: ['to_account_id'], message: 'Selecione a conta destino' });
+    } else {
+      if (!d.category_id && !d.category_parent)
+        ctx.addIssue({ code: 'custom', path: ['category_id'], message: 'Selecione a categoria' });
+      if (!d.source.id)
+        ctx.addIssue({ code: 'custom', path: ['source'], message: 'Selecione conta ou cartão' });
+    }
+  });
 
 export function ModalTransacao({ open, onClose, initialData, onSubmit }: Props) {
-  const [form, setForm] = useState<BaseData>({
-    date: new Date().toISOString().slice(0,10),
-    description: '',
-    value: 0,
-    type: 'expense',
-    category: 'Outros',
-    payment_method: 'Outro',
-    source_kind: 'account',
-    source_label: null,
-    installments: null,
-    notes: null,
-    attachment_file: null,
-  });
+  const [form, setForm] = useState<FormData>(defaultForm);
+  const [errors, setErrors] = useState<Record<string, string>>({});
   const [loading, setLoading] = useState(false);
 
-  useEffect(() => {
-    if (initialData) {
-      setForm((prev) => ({
-        ...prev,
-        ...initialData,
-        attachment_file: null, // não herdamos arquivo
-        date: initialData.date || new Date().toISOString().slice(0,10),
-      }));
-    } else {
-      setForm((f) => ({ ...f, date: new Date().toISOString().slice(0,10) }));
-    }
-  }, [initialData, open]);
+  const { data: accounts } = useAccounts();
+  const { flat: categories } = useCategories();
 
-  const handleChange = (key: keyof BaseData, v: any) => setForm(prev => ({ ...prev, [key]: v }));
+  useEffect(() => {
+    if (open) {
+      setForm((f) => ({ ...defaultForm, ...initialData, amount: initialData?.amount ?? 0 }));
+      setErrors({});
+    }
+  }, [open, initialData]);
+
+  const handleChange = (key: keyof FormData, value: any) => {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  };
+
+  const parentCats = categories.filter((c) => c.parent_id === null && c.kind === form.type);
+  const subCats = categories.filter((c) => c.parent_id === form.category_parent);
 
   const handleSubmit = async () => {
-    if (!form.description || !form.date || !form.category || !form.type) return;
-    const n = Number(form.value);
-    if (Number.isNaN(n) || n <= 0) return;
-
+    const parse = schema.safeParse(form);
+    if (!parse.success) {
+      const fieldErrors: Record<string, string> = {};
+      parse.error.issues.forEach((i) => {
+        const k = i.path[0] as string;
+        fieldErrors[k] = i.message;
+      });
+      setErrors(fieldErrors);
+      return;
+    }
+    setErrors({});
     setLoading(true);
+    const data = parse.data;
     try {
-      // envia apenas dados serializáveis; arquivo será tratado fora (futuro)
-      const payload: BaseData = {
-        ...form,
-        value: n,
-      };
-      await onSubmit(payload);
+      if (data.type === 'transfer') {
+        // Abordagem simples: gera duas transações (saída e entrada) na tabela `transactions`.
+        const amount = data.amount;
+        const rows = [
+          {
+            date: data.date,
+            description: data.description,
+            amount: -amount,
+            account_id: data.from_account_id,
+            category_id: null,
+            notes: data.notes || null,
+          },
+          {
+            date: data.date,
+            description: data.description,
+            amount: amount,
+            account_id: data.to_account_id,
+            category_id: null,
+            notes: data.notes || null,
+          },
+        ];
+        await onSubmit(rows);
+        toast.success('Transferência registrada!');
+      } else {
+        const amount = data.type === 'expense' ? -data.amount : data.amount;
+        const payload: any = {
+          date: data.date,
+          description: data.description,
+          amount,
+          category_id: data.category_id || data.category_parent,
+          notes: data.notes || null,
+          attachment_file: data.attachment_file || null,
+        };
+        if (data.source.kind === 'account') payload.account_id = data.source.id;
+        else payload.card_id = data.source.id;
+        if (data.source.kind === 'card') payload.installment_total = data.installments;
+        await onSubmit(payload);
+        toast.success('Transação salva!');
+      }
       onClose();
+    } catch (e: any) {
+      console.error(e);
+      toast.error('Erro ao salvar', { description: e?.message });
     } finally {
       setLoading(false);
     }
   };
 
-  const showInstallments = form.type === 'expense' && (form.payment_method || '').toLowerCase().startsWith('cart');
+  const showInstallments = form.type === 'expense' && form.source.kind === 'card';
 
   return (
     <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>{initialData ? 'Editar Transação' : 'Nova Transação'}</DialogTitle>
-        </DialogHeader>
+      <DialogPortal>
+        <DialogOverlay className="backdrop-blur-sm" />
+        <DialogContent className="sm:max-w-lg">
+          <motion.div initial={{ opacity: 0, y: -10 }} animate={{ opacity: 1, y: 0 }}>
+            <DialogHeader>
+              <DialogTitle>{initialData ? 'Editar Transação' : 'Nova Transação'}</DialogTitle>
+            </DialogHeader>
 
-        <div className="grid gap-4 py-2">
-          {/* Data & Valor */}
-          <div className="grid gap-1">
-            <Label>Data</Label>
-            <Input type="date" value={form.date} onChange={(e) => handleChange('date', e.target.value)} />
-          </div>
-
-          <div className="grid gap-1">
-            <Label>Descrição</Label>
-            <Input
-              placeholder="Ex.: Mercado, Salário..."
-              value={form.description}
-              onChange={(e) => handleChange('description', e.target.value)}
-            />
-          </div>
-
-          <div className="grid gap-1">
-            <Label>Valor (R$)</Label>
-            <Input
-              type="number"
-              step="0.01"
-              inputMode="decimal"
-              value={form.value}
-              onChange={(e) => handleChange('value', Number(e.target.value))}
-            />
-            <span className="text-xs text-slate-500">Sempre informe valor positivo — o tipo abaixo define se é receita ou despesa.</span>
-          </div>
-
-          {/* Tipo & Categoria */}
-          <div className="grid sm:grid-cols-2 gap-4">
-            <div className="grid gap-1">
-              <Label>Tipo</Label>
-              <Select value={form.type} onValueChange={(v: 'income' | 'expense') => handleChange('type', v)}>
-                <SelectTrigger><SelectValue placeholder="Selecione" /></SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="expense">Despesa</SelectItem>
-                  <SelectItem value="income">Receita</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="grid gap-1">
-              <Label>Categoria</Label>
-              <Select value={form.category} onValueChange={(v) => handleChange('category', v)}>
-                <SelectTrigger><SelectValue placeholder="Selecione" /></SelectTrigger>
-                <SelectContent>
-                  {CATEGORIAS.map(c => <SelectItem key={c} value={c}>{c}</SelectItem>)}
-                </SelectContent>
-              </Select>
-            </div>
-          </div>
-
-          {/* Pagamento */}
-          <div className="grid sm:grid-cols-2 gap-4">
-            <div className="grid gap-1">
-              <Label>Método de pagamento</Label>
-              <Select value={form.payment_method} onValueChange={(v) => handleChange('payment_method', v)}>
-                <SelectTrigger><SelectValue placeholder="Selecione" /></SelectTrigger>
-                <SelectContent>
-                  {METODOS.map(m => <SelectItem key={m} value={m}>{m}</SelectItem>)}
-                </SelectContent>
-              </Select>
-            </div>
-
-            <div className="grid gap-1">
-              <Label>Fonte de pagamento</Label>
-              <div className="inline-flex overflow-hidden rounded-xl border border-white/30">
-                <button
-                  type="button"
-                  className={`px-3 py-2 text-sm ${form.source_kind === 'account' ? 'bg-emerald-600 text-white' : 'text-slate-700 dark:text-slate-200'}`}
-                  onClick={() => handleChange('source_kind', 'account')}
-                >Conta</button>
-                <button
-                  type="button"
-                  className={`px-3 py-2 text-sm ${form.source_kind === 'card' ? 'bg-emerald-600 text-white' : 'text-slate-700 dark:text-slate-200'}`}
-                  onClick={() => handleChange('source_kind', 'card')}
-                >Cartão</button>
-              </div>
-            </div>
-          </div>
-
-          <div className="grid gap-1">
-            <Label>{form.source_kind === 'card' ? 'Cartão (nome/identificação)' : 'Conta (nome/identificação)'}</Label>
-            <Input
-              placeholder={form.source_kind === 'card' ? 'Ex.: Nubank Visa final 1234' : 'Ex.: Itaú Conta Corrente'}
-              value={form.source_label || ''}
-              onChange={(e) => handleChange('source_label', e.target.value)}
-            />
-            <span className="text-xs text-slate-500">(Rascunho temporário — depois ligaremos à lista real de contas/cartões.)</span>
-          </div>
-
-          {/* Parcelas (se cartão e despesa) */}
-          {showInstallments && (
-            <div className="grid sm:grid-cols-2 gap-4">
+            <div className="grid gap-4 py-2">
               <div className="grid gap-1">
-                <Label>Parcelas</Label>
-                <Input
-                  type="number"
-                  min={1}
-                  max={36}
-                  value={form.installments || 1}
-                  onChange={(e) => handleChange('installments', Math.max(1, Number(e.target.value || 1)))}
-                />
+                <Label>Data</Label>
+                <Input type="date" value={form.date} onChange={(e) => handleChange('date', e.target.value)} />
+                {errors.date && <p className="text-xs text-red-500">{errors.date}</p>}
               </div>
+
+              <div className="grid gap-1">
+                <Label>Descrição</Label>
+                <Input value={form.description} onChange={(e) => handleChange('description', e.target.value)} />
+                {errors.description && <p className="text-xs text-red-500">{errors.description}</p>}
+              </div>
+
+              <div className="grid gap-1">
+                <Label>Valor</Label>
+                <MoneyInput value={form.amount} onChange={(v) => handleChange('amount', v)} autoFocus />
+                {errors.amount && <p className="text-xs text-red-500">{errors.amount}</p>}
+              </div>
+
+              <div className="grid gap-1">
+                <Label>Tipo</Label>
+                <Select value={form.type} onValueChange={(v: any) => handleChange('type', v)}>
+                  <SelectTrigger>
+                    <SelectValue placeholder="Selecione" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="income">Receita</SelectItem>
+                    <SelectItem value="expense">Despesa</SelectItem>
+                    <SelectItem value="transfer">Transferência</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {form.type !== 'transfer' && (
+                <>
+                  <div className="grid gap-1">
+                    <Label>Categoria</Label>
+                    <select
+                      className="w-full rounded-xl border border-white/30 bg-white/70 px-3 py-2 text-sm outline-none backdrop-blur dark:border-white/10 dark:bg-zinc-900/50"
+                      value={form.category_parent || ''}
+                      onChange={(e) => handleChange('category_parent', e.target.value || null)}
+                    >
+                      <option value="">Selecione</option>
+                      {parentCats.map((c) => (
+                        <option key={c.id} value={c.id}>
+                          {c.name}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                  {subCats.length > 0 && (
+                    <div className="grid gap-1">
+                      <Label>Subcategoria</Label>
+                      <select
+                        className="w-full rounded-xl border border-white/30 bg-white/70 px-3 py-2 text-sm outline-none backdrop-blur dark:border-white/10 dark:bg-zinc-900/50"
+                        value={form.category_id || ''}
+                        onChange={(e) => handleChange('category_id', e.target.value || null)}
+                      >
+                        <option value="">Selecione</option>
+                        {subCats.map((sc) => (
+                          <option key={sc.id} value={sc.id}>
+                            {sc.name}
+                          </option>
+                        ))}
+                      </select>
+                      {errors.category_id && <p className="text-xs text-red-500">{errors.category_id}</p>}
+                    </div>
+                  )}
+
+                  <div className="grid gap-1">
+                    <Label>Fonte de pagamento</Label>
+                    <SourcePicker value={form.source} onChange={(s) => handleChange('source', s)} />
+                    {errors.source && <p className="text-xs text-red-500">{errors.source}</p>}
+                  </div>
+                </>
+              )}
+
+              {form.type === 'transfer' && (
+                <div className="grid sm:grid-cols-2 gap-4">
+                  <div className="grid gap-1">
+                    <Label>De</Label>
+                    <select
+                      className="w-full rounded-xl border border-white/30 bg-white/70 px-3 py-2 text-sm outline-none backdrop-blur dark:border-white/10 dark:bg-zinc-900/50"
+                      value={form.from_account_id || ''}
+                      onChange={(e) => handleChange('from_account_id', e.target.value || null)}
+                    >
+                      <option value="">Selecione</option>
+                      {accounts.map((a) => (
+                        <option key={a.id} value={a.id}>
+                          {a.name}
+                        </option>
+                      ))}
+                    </select>
+                    {errors.from_account_id && <p className="text-xs text-red-500">{errors.from_account_id}</p>}
+                  </div>
+                  <div className="grid gap-1">
+                    <Label>Para</Label>
+                    <select
+                      className="w-full rounded-xl border border-white/30 bg-white/70 px-3 py-2 text-sm outline-none backdrop-blur dark:border-white/10 dark:bg-zinc-900/50"
+                      value={form.to_account_id || ''}
+                      onChange={(e) => handleChange('to_account_id', e.target.value || null)}
+                    >
+                      <option value="">Selecione</option>
+                      {accounts.map((a) => (
+                        <option key={a.id} value={a.id}>
+                          {a.name}
+                        </option>
+                      ))}
+                    </select>
+                    {errors.to_account_id && <p className="text-xs text-red-500">{errors.to_account_id}</p>}
+                  </div>
+                </div>
+              )}
+
+              {showInstallments && (
+                <div className="grid gap-1">
+                  <Label>Parcelas</Label>
+                  <Select value={String(form.installments)} onValueChange={(v) => handleChange('installments', Number(v))}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {Array.from({ length: 24 }, (_, i) => i + 1).map((n) => (
+                        <SelectItem key={n} value={String(n)}>
+                          {n}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              )}
+
               <div className="grid gap-1">
                 <Label>Observações</Label>
+                <Input value={form.notes} onChange={(e) => handleChange('notes', e.target.value)} />
+              </div>
+
+              <div className="grid gap-1">
+                <Label>Anexo (PDF/JPG/PNG)</Label>
                 <input
-                  className="rounded-md border px-3 py-2 text-sm"
-                  placeholder="Opcional"
-                  value={form.notes || ''}
-                  onChange={(e) => handleChange('notes', e.target.value)}
+                  type="file"
+                  accept="application/pdf,image/png,image/jpeg"
+                  onChange={(e) => handleChange('attachment_file', e.target.files?.[0] || null)}
                 />
               </div>
             </div>
-          )}
 
-          {/* Anexo (nota/recibo) */}
-          <div className="grid gap-1">
-            <Label>Anexo (nota/recibo — PDF/Imagem)</Label>
-            <input
-              type="file"
-              accept="application/pdf,image/*"
-              onChange={(e) => handleChange('attachment_file', e.target.files?.[0] || null)}
-            />
-            <span className="text-xs text-slate-500">(Opcional; upload/extração OCR entram no próximo passo.)</span>
-          </div>
-        </div>
-
-        <DialogFooter>
-          <Button variant="ghost" onClick={onClose} disabled={loading}>Cancelar</Button>
-          <Button onClick={handleSubmit} disabled={loading}>
-            {loading ? 'Salvando…' : 'Salvar'}
-          </Button>
-        </DialogFooter>
-      </DialogContent>
+            <DialogFooter>
+              <Button variant="ghost" onClick={onClose} disabled={loading}>
+                Cancelar
+              </Button>
+              <Button onClick={handleSubmit} disabled={loading}>
+                {loading ? 'Salvando…' : 'Salvar'}
+              </Button>
+            </DialogFooter>
+          </motion.div>
+        </DialogContent>
+      </DialogPortal>
     </Dialog>
   );
 }

--- a/src/components/MoneyInput.tsx
+++ b/src/components/MoneyInput.tsx
@@ -4,8 +4,9 @@ type Props = {
   value: number;
   onChange: (v: number) => void;
   placeholder?: string;
+  autoFocus?: boolean;
 };
-export default function MoneyInput({ value, onChange, placeholder }: Props) {
+export default function MoneyInput({ value, onChange, placeholder, autoFocus }: Props) {
   const [raw, setRaw] = React.useState(
     (value ?? 0).toLocaleString("pt-BR", { minimumFractionDigits: 2, maximumFractionDigits: 2 })
   );
@@ -25,6 +26,7 @@ export default function MoneyInput({ value, onChange, placeholder }: Props) {
       inputMode="decimal"
       value={raw}
       placeholder={placeholder || "0,00"}
+      autoFocus={autoFocus}
       onChange={(e) => {
         const v = e.target.value;
         setRaw(v);


### PR DESCRIPTION
## Summary
- expand transaction modal with validation, transfer support and animated layout
- allow focusing MoneyInput and add zod dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 101 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6897bbec760083228ade3dcbc12272d0