### PR TITLE
Add finances overview and annual analysis pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { PeriodProvider } from './state/periodFilter';
 const Dashboard      = lazy(() => import('./pages/Dashboard'));
 const FinancasMensal = lazy(() => import('./pages/FinancasMensal'));
 const FinancasAnual  = lazy(() => import('./pages/FinancasAnual'));
+const Financas      = lazy(() => import('./pages/Financas'));
 
 // ✅ manter apenas a página em PT-BR
 const Investimentos  = lazy(() => import('./pages/Investimentos'));
@@ -74,6 +75,7 @@ function AppRoutes() {
             <Route path="/dashboard" element={<Dashboard />} />
 
             {/* Finanças */}
+            <Route path="/financas" element={<Financas />} />
             <Route path="/financas/mensal" element={<FinancasMensal />} />
             <Route path="/financas/anual"  element={<FinancasAnual />} />
 

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -21,6 +21,7 @@ const sections: Section[] = [
       {
         type: "group", label: "Finanças", icon: Wallet,
         children: [
+          { type: "item", label: "Resumo", to: "/financas", icon: LayoutDashboard },
           { type: "item", label: "Mensal", to: "/financas/mensal", icon: CalendarRange },
           { type: "item", label: "Anual", to: "/financas/anual", icon: CalendarRange },
         ],

--- a/src/components/charts/MonthlyBars.tsx
+++ b/src/components/charts/MonthlyBars.tsx
@@ -1,0 +1,36 @@
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import { SERIES_COLORS } from '@/lib/palette';
+
+const MESES = ['Jan','Fev','Mar','Abr','Mai','Jun','Jul','Ago','Set','Out','Nov','Dez'];
+
+type Tx = { date: string; amount: number };
+
+export default function MonthlyBars({ transacoes }: { transacoes: Tx[] }) {
+  const data = MESES.map((m, idx) => {
+    const receitas = transacoes
+      .filter(t => new Date(t.date).getMonth() === idx && t.amount > 0)
+      .reduce((s, t) => s + t.amount, 0);
+    const despesas = transacoes
+      .filter(t => new Date(t.date).getMonth() === idx && t.amount < 0)
+      .reduce((s, t) => s + Math.abs(t.amount), 0);
+    return { mes: m, receitas, despesas };
+  });
+
+  return (
+    <div className="rounded-xl border bg-white dark:bg-slate-900 p-4">
+      <h3 className="font-medium mb-3">Movimento mensal</h3>
+      <div className="h-[320px]">
+        <ResponsiveContainer>
+          <BarChart data={data}>
+            <XAxis dataKey="mes" />
+            <YAxis />
+            <Tooltip formatter={(v: any) => `R$ ${Number(v).toFixed(2)}`} />
+            <Legend />
+            <Bar dataKey="despesas" name="Despesas" fill={SERIES_COLORS.expense} />
+            <Bar dataKey="receitas" name="Receitas" fill={SERIES_COLORS.income} />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useTransactionsYear.ts
+++ b/src/hooks/useTransactionsYear.ts
@@ -1,0 +1,79 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { supabase } from '@/lib/supabaseClient';
+import type { Transaction } from './useTransactions';
+
+export function useTransactionsYear(year?: any) {
+  const [data, setData] = useState<Transaction[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const y = useMemo(() => {
+    const n = Number(year);
+    return Number.isInteger(n) && n >= 1970 && n <= 9999 ? n : new Date().getFullYear();
+  }, [year]);
+
+  const start = `${y}-01-01`;
+  const end = `${y}-12-31`;
+
+  const list = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const { data, error } = await supabase
+        .from('transactions')
+        .select('*')
+        .gte('date', start)
+        .lte('date', end)
+        .order('date', { ascending: true });
+      if (error) throw error;
+      setData((data || []) as Transaction[]);
+    } catch (e: any) {
+      console.error('[useTransactionsYear] list error:', e);
+      setError(e?.message || 'Erro ao listar');
+      setData([]);
+    } finally {
+      setLoading(false);
+    }
+  }, [start, end]);
+
+  useEffect(() => {
+    void list();
+  }, [list]);
+
+  const create = async (t: Omit<Transaction, 'id'>) => {
+    const { error } = await supabase.from('transactions').insert(t as any);
+    if (error) throw error;
+    await list();
+  };
+
+  const bulkCreate = async (rows: Omit<Transaction, 'id'>[]) => {
+    const { error } = await supabase.from('transactions').insert(rows as any);
+    if (error) throw error;
+    await list();
+  };
+
+  const update = async (id: number, patch: Partial<Transaction>) => {
+    const { error } = await supabase.from('transactions').update(patch).eq('id', id);
+    if (error) throw error;
+    await list();
+  };
+
+  const remove = async (id: number) => {
+    const { error } = await supabase.from('transactions').delete().eq('id', id);
+    if (error) throw error;
+    await list();
+  };
+
+  const kpis = useMemo(() => {
+    const entradas = data.filter(d => d.amount > 0).reduce((s, d) => s + d.amount, 0);
+    const saidas = data.filter(d => d.amount < 0).reduce((s, d) => s + d.amount, 0);
+    return {
+      entradas,
+      saidas: Math.abs(saidas),
+      saldo: entradas + saidas,
+    };
+  }, [data]);
+
+  const add = create;
+  return { data, loading, error, list, create, add, bulkCreate, update, remove, kpis, start, end, year: y };
+}

--- a/src/pages/Financas.tsx
+++ b/src/pages/Financas.tsx
@@ -1,0 +1,87 @@
+import { Link } from 'react-router-dom';
+import { usePeriod } from '@/state/periodFilter';
+import FilterBar from '@/components/FilterBar';
+import { useTransactions } from '@/hooks/useTransactions';
+import { useTransactionsYear } from '@/hooks/useTransactionsYear';
+import { PageHeader } from '@/components/PageHeader';
+import { MotionCard } from '@/components/ui/MotionCard';
+import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
+import DailyBars from '@/components/charts/DailyBars';
+import MonthlyBars from '@/components/charts/MonthlyBars';
+import CategoryDonut from '@/components/charts/CategoryDonut';
+import { Button } from '@/components/ui/button';
+import { Coins, TrendingUp, TrendingDown } from 'lucide-react';
+
+export default function Financas() {
+  const period = usePeriod();
+  const { mode, month, year } = period;
+
+  const txHook = mode === 'monthly'
+    ? useTransactions(year, month)
+    : useTransactionsYear(year);
+
+  const { data: transacoes, kpis, loading } = txHook;
+  const mesStr = `${year}-${String(month).padStart(2, '0')}`;
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Finanças"
+        subtitle="Resumo do período selecionado"
+        actions={
+          <div className="flex gap-2">
+            <Button asChild variant="secondary"><Link to="/financas/mensal">Mensal</Link></Button>
+            <Button asChild variant="secondary"><Link to="/financas/anual">Anual</Link></Button>
+          </div>
+        }
+      />
+
+      <FilterBar />
+
+      {/* KPIs */}
+      <section className="grid gap-4 sm:grid-cols-2 xl:grid-cols-3">
+        <MotionCard>
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-full bg-emerald-600 text-white"><Coins size={18} /></div>
+            <div className="flex flex-col">
+              <span className="text-sm text-slate-500 dark:text-slate-300">Saldo</span>
+              <AnimatedNumber value={kpis.saldo} />
+            </div>
+          </div>
+        </MotionCard>
+        <MotionCard>
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-full bg-blue-600 text-white"><TrendingUp size={18} /></div>
+            <div className="flex flex-col">
+              <span className="text-sm text-slate-500 dark:text-slate-300">Entradas</span>
+              <AnimatedNumber value={kpis.entradas} />
+            </div>
+          </div>
+        </MotionCard>
+        <MotionCard>
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-full bg-rose-500 text-white"><TrendingDown size={18} /></div>
+            <div className="flex flex-col">
+              <span className="text-sm text-slate-500 dark:text-slate-300">Saídas</span>
+              <AnimatedNumber value={-kpis.saidas} />
+            </div>
+          </div>
+        </MotionCard>
+      </section>
+
+      {/* Gráficos */}
+      <section className="grid gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          {mode === 'monthly'
+            ? <DailyBars transacoes={transacoes as any} mes={mesStr} />
+            : <MonthlyBars transacoes={transacoes as any} />}
+        </div>
+        <div className="lg:col-span-1">
+          <CategoryDonut transacoes={transacoes as any} />
+        </div>
+      </section>
+
+      {loading && <p>Carregando…</p>}
+    </div>
+  );
+}

--- a/src/pages/FinancasAnual.tsx
+++ b/src/pages/FinancasAnual.tsx
@@ -1,3 +1,143 @@
+import { useMemo, useState } from 'react';
+import dayjs from 'dayjs';
+import 'dayjs/locale/pt-br';
+
+import { useTransactionsYear } from '@/hooks/useTransactionsYear';
+import { PageHeader } from '@/components/PageHeader';
+import { MotionCard } from '@/components/ui/MotionCard';
+import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
+import MonthlyBars from '@/components/charts/MonthlyBars';
+import CategoryDonut from '@/components/charts/CategoryDonut';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+
+const ANOS: number[] = (() => {
+  const y = new Date().getFullYear();
+  const arr: number[] = [];
+  for (let i = y + 1; i >= y - 6; i--) arr.push(i);
+  return arr;
+})();
+
+dayjs.locale('pt-br');
+
 export default function FinancasAnual() {
-  return <h1 className="text-2xl font-bold">💰 Finanças - Anual</h1>;
+  const [ano, setAno] = useState(new Date().getFullYear());
+  const { data, loading } = useTransactionsYear(ano);
+
+  const mensal = useMemo(() => {
+    const base = Array.from({ length: 12 }, (_, i) => ({
+      mes: i,
+      entradas: 0,
+      saidas: 0,
+      saldo: 0,
+    }));
+    data.forEach((t) => {
+      const m = dayjs(t.date).month();
+      if (t.amount > 0) base[m].entradas += t.amount;
+      else base[m].saidas += Math.abs(t.amount);
+    });
+    base.forEach((b) => {
+      b.saldo = b.entradas - b.saidas;
+    });
+    return base;
+  }, [data]);
+
+  const categorias = useMemo(() => {
+    const map = new Map<string, number>();
+    data
+      .filter((t) => t.amount < 0)
+      .forEach((t) => {
+        const cat = (t as any).category || 'Outros';
+        map.set(cat, (map.get(cat) || 0) + Math.abs(t.amount));
+      });
+    return Array.from(map.entries()).sort((a, b) => b[1] - a[1]);
+  }, [data]);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader title="Finanças Anual" subtitle="Visão consolidada por ano" />
+
+      <div className="flex flex-wrap gap-4">
+        <div className="min-w-[160px]">
+          <span className="mb-1 block text-xs text-emerald-100/90">Ano</span>
+          <Select value={String(ano)} onValueChange={(v) => setAno(Number(v))}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Ano" />
+            </SelectTrigger>
+            <SelectContent>
+              {ANOS.map((a) => (
+                <SelectItem key={a} value={String(a)}>
+                  {a}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+
+      {/* Cards por mês */}
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {mensal.map((m) => (
+          <MotionCard key={m.mes} className="space-y-2">
+            <h3 className="text-sm font-medium">
+              {dayjs().month(m.mes).format('MMMM')}
+            </h3>
+            <div className="flex flex-col gap-1 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-slate-500 dark:text-slate-300">Entradas</span>
+                <AnimatedNumber value={m.entradas} />
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-slate-500 dark:text-slate-300">Saídas</span>
+                <AnimatedNumber value={-m.saidas} />
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-slate-500 dark:text-slate-300">Saldo</span>
+                <AnimatedNumber value={m.saldo} />
+              </div>
+            </div>
+          </MotionCard>
+        ))}
+      </section>
+
+      {/* Gráficos */}
+      <section className="grid gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <MonthlyBars transacoes={data} />
+        </div>
+        <div className="lg:col-span-1">
+          <CategoryDonut transacoes={data as any} />
+        </div>
+      </section>
+
+      {/* Tabela de categorias */}
+      <section className="rounded-xl border bg-white dark:bg-slate-900 p-4">
+        <h3 className="font-medium mb-3">Despesas por categoria</h3>
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left">
+                <th>Categoria</th>
+                <th className="text-right">Valor</th>
+              </tr>
+            </thead>
+            <tbody>
+              {categorias.map(([cat, val]) => (
+                <tr key={cat} className="border-t">
+                  <td className="py-1">{cat}</td>
+                  <td className="py-1 text-right">
+                    {val.toLocaleString('pt-BR', {
+                      style: 'currency',
+                      currency: 'BRL',
+                    })}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      {loading && <p>Carregando…</p>}
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary
- create `/financas` overview with period filter, KPIs and charts
- implement detailed annual finances page with monthly cards and category table
- add `useTransactionsYear` hook and monthly bar chart component

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: @typescript-eslint/no-unused-vars and others)


------
https://chatgpt.com/codex/tasks/task_e_6897bbfa49948322bf6caa573e0de526