### PR TITLE
docs: add ci and backup workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run build

--- a/.github/workflows/nightly-backup.yml
+++ b/.github/workflows/nightly-backup.yml
@@ -1,0 +1,26 @@
+name: Nightly Backup
+
+on:
+  schedule:
+    - cron: "0 0 * * *"
+  workflow_dispatch:
+
+jobs:
+  backup:
+    runs-on: ubuntu-latest
+    env:
+      DATABASE_URL: ${{ secrets.DATABASE_URL }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install PostgreSQL client
+        run: sudo apt-get update && sudo apt-get install -y postgresql-client
+      - name: Dump schema
+        run: pg_dump --schema-only "$DATABASE_URL" > schema.sql
+      - name: Dump data
+        run: pg_dump --data-only --inserts "$DATABASE_URL" > seed.sql
+      - uses: actions/upload-artifact@v4
+        with:
+          name: supabase-backup
+          path: |
+            schema.sql
+            seed.sql

--- a/README.md
+++ b/README.md
@@ -1,0 +1,33 @@
+# Financeiro do Yago
+
+Aplicação financeira construída com React, Vite e Supabase.
+
+## Setup
+1. Instale as dependências:
+   ```bash
+   npm ci
+   ```
+2. Configure as variáveis de ambiente:
+   - `VITE_SUPABASE_URL`
+   - `VITE_SUPABASE_ANON_KEY`
+   
+   No Vercel, adicione essas variáveis no painel do projeto.
+3. Inicie o ambiente de desenvolvimento:
+   ```bash
+   npm run dev
+   ```
+
+## Backups e Restauração
+### Backups
+- O workflow `nightly-backup` exporta `schema.sql` e `seed.sql` diariamente usando `pg_dump` e armazena os arquivos como artifact do GitHub.
+- Localmente você pode usar `./backup-all.sh` para gerar um pacote completo com código, variáveis de ambiente e banco.
+
+### Restauração
+1. Restaure o schema:
+   ```bash
+   psql "$DATABASE_URL" < schema.sql
+   ```
+2. Restaure os dados:
+   ```bash
+   psql "$DATABASE_URL" < seed.sql
+   ```


### PR DESCRIPTION
## Summary
- add CI workflow to install deps, lint and build
- schedule nightly database backup with pg_dump
- document setup and backup instructions in README

## Testing
- `npm run lint` *(fails: '@typescript-eslint/no-unused-vars', 'Unexpected any', etc.)*
- `npm run build` *(fails: 'Property "children" does not exist on type "IntrinsicAttributes & PageHeaderProps"', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6897bc24b9488322ae10ee821c6ded5c