### PR TITLE
fix: polyfill web crypto for old node

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,13 @@
+import { webcrypto } from 'node:crypto'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import path from 'path'
+
+// Polyfill Web Crypto for Node versions lacking getRandomValues
+if (!globalThis.crypto?.getRandomValues) {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  globalThis.crypto = webcrypto as any
+}
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- polyfill Web Crypto API so dev server runs on older Node versions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 114 problems)*
- `npm run build` *(fails: TypeScript errors in FinancasAnual.tsx and FinancasMensal.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_6897c45608288322b4a50501c2841b0c