### PR TITLE
Fontes: CRUD inline + badges de conta/cartão na lista

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -6,9 +6,10 @@ type PageHeaderProps = {
   subtitle?: string;
   icon?: ReactNode;
   actions?: ReactNode;
+  children?: ReactNode;
 };
 
-const PageHeader = ({ title, subtitle, icon, actions }: PageHeaderProps) => {
+const PageHeader = ({ title, subtitle, icon, actions, children }: PageHeaderProps) => {
   return (
     <div className="mb-6 rounded-xl bg-gradient-to-r from-emerald-900 to-teal-700 text-white">
       <div className="container mx-auto px-4 py-5 flex items-center justify-between gap-4">
@@ -23,8 +24,11 @@ const PageHeader = ({ title, subtitle, icon, actions }: PageHeaderProps) => {
         </div>
         {actions ? <div className="shrink-0">{actions}</div> : null}
       </div>
+      {children ? (
+        <div className="container mx-auto px-4 pb-4">{children}</div>
+      ) : null}
     </div>
   );
-}
+};
 
 export default PageHeader;

--- a/src/hooks/useCreditCards.ts
+++ b/src/hooks/useCreditCards.ts
@@ -4,15 +4,20 @@ import { supabase } from "@/lib/supabaseClient";
 export type CreditCard = {
   id: string;
   name: string;
-  bank: string | null;
-  limit_amount: number | null; // em centavos ou reais? aqui tratamos como reais (número)
-  cut_day: number | null;      // dia do fechamento (1-31)
-  due_day: number | null;      // dia do vencimento (1-31)
-  account_id: string | null;   // conta para débito da fatura (opcional)
+  brand?: "visa" | "mastercard" | "elo" | "amex" | "hipercard" | string | null;
+  limit_amount?: number | null;
+  last4?: string | null;
+  color?: string | null;
+  created_at?: string;
+  // campos legados ainda usados
+  bank?: string | null;
+  cut_day?: number | null;
+  due_day?: number | null;
+  account_id?: string | null;
 };
 
 // ------- helpers internos -------
-function clampDay(n: any): number | null {
+function clampDay(n: unknown): number | null {
   if (n === null || n === undefined) return null;
   const v = Math.max(1, Math.min(31, Number(n)));
   return Number.isFinite(v) ? v : null;
@@ -68,81 +73,104 @@ export function useCreditCards() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const list = useCallback(async () => {
+  const list = useCallback(async (): Promise<CreditCard[]> => {
     setLoading(true);
     setError(null);
-    const { data, error } = await supabase
-      .from("credit_cards")
-      .select("id,name,bank,limit_amount,cut_day,due_day,account_id")
+    const { data: rows, error } = await supabase
+      .from<CreditCard>("credit_cards")
+      .select("*")
       .order("name", { ascending: true });
     if (error) {
       setError(error.message);
       setData([]);
-    } else {
-      setData((data || []) as CreditCard[]);
+      setLoading(false);
+      return [];
     }
+    setData(rows ?? []);
     setLoading(false);
+    return rows ?? [];
   }, []);
 
   useEffect(() => { void list(); }, [list]);
 
   // ---------- CRUD ----------
-  type CreatePayload = Pick<CreditCard, "name"> &
-    Partial<Pick<CreditCard, "bank" | "limit_amount" | "cut_day" | "due_day" | "account_id">>;
+  const create = useCallback(
+    async (payload: Omit<CreditCard, "id" | "created_at">): Promise<CreditCard> => {
+      const base = sanitize(payload);
+      const { data: row, error } = await supabase
+        .from<CreditCard>("credit_cards")
+        .insert(base)
+        .select("*")
+        .single();
+      if (error) throw error;
+      setData((d) => [...d, row]);
+      return row;
+    },
+    []
+  );
 
-  const create = useCallback(async (payload: CreatePayload) => {
-    const base = sanitize(payload);
-    const toInsert = {
-      name: base.name!,
-      bank: base.bank ?? null,
-      limit_amount: base.limit_amount ?? null,
-      cut_day: base.cut_day ?? null,
-      due_day: base.due_day ?? null,
-      account_id: base.account_id ?? null,
-    };
-    const { error } = await supabase.from("credit_cards").insert(toInsert);
-    if (error) throw error;
-    await list();
-  }, [list]);
+  const update = useCallback(
+    async (id: string, patch: Partial<Omit<CreditCard, "id">>): Promise<void> => {
+      const upd = sanitize(patch);
+      const { error } = await supabase
+        .from<CreditCard>("credit_cards")
+        .update(upd)
+        .eq("id", id);
+      if (error) throw error;
+      await list();
+    },
+    [list]
+  );
 
-  const update = useCallback(async (id: string, patch: Partial<Omit<CreditCard, "id">>) => {
-    const upd = sanitize(patch);
-    const { error } = await supabase.from("credit_cards").update(upd).eq("id", id);
-    if (error) throw error;
-    await list();
-  }, [list]);
+  const remove = useCallback(
+    async (id: string): Promise<void> => {
+      const { error } = await supabase.from("credit_cards").delete().eq("id", id);
+      if (error) throw error;
+      setData((d) => d.filter((c) => c.id !== id));
+    },
+    []
+  );
 
-  const remove = useCallback(async (id: string) => {
-    const { error } = await supabase.from("credit_cards").delete().eq("id", id);
-    if (error) throw error;
-    await list();
-  }, [list]);
+  const removeMany = useCallback(
+    async (ids: string[]): Promise<void> => {
+      if (!ids.length) return;
+      const { error } = await supabase.from("credit_cards").delete().in("id", ids);
+      if (error) throw error;
+      setData((d) => d.filter((c) => !ids.includes(c.id)));
+    },
+    []
+  );
 
-  const removeMany = useCallback(async (ids: string[]) => {
-    if (!ids?.length) return;
-    const { error } = await supabase.from("credit_cards").delete().in("id", ids);
-    if (error) throw error;
-    await list();
-  }, [list]);
-
-  const upsert = useCallback(async (payload: Partial<CreditCard>) => {
-    if (payload.id) {
-      const { id, ...rest } = payload as CreditCard;
-      return update(id, rest);
-    }
-    return create(payload as CreatePayload);
-  }, [create, update]);
+  const upsert = useCallback(
+    async (payload: Partial<CreditCard>) => {
+      if (payload.id) {
+        const { id, ...rest } = payload;
+        return update(id, rest);
+      }
+      return create(payload as Omit<CreditCard, "id" | "created_at">);
+    },
+    [create, update]
+  );
 
   // ---------- Helpers ----------
   const findById = useCallback((id: string) => data.find(c => c.id === id) ?? null, [data]);
   const findByName = useCallback((name: string) => data.find(c => c.name === name) ?? null, [data]);
 
-  const setLimit = useCallback(async (id: string, limit_amount: number | null) => update(id, { limit_amount }), [update]);
-  const setCutDue = useCallback(async (id: string, cut_day: number | null, due_day: number | null) => update(id, { cut_day, due_day }), [update]);
-  const attachAccount = useCallback(async (id: string, account_id: string | null) => update(id, { account_id }), [update]);
+  const setLimit = useCallback(
+    async (id: string, limit_amount: number | null) => update(id, { limit_amount }),
+    [update]
+  );
+  const setCutDue = useCallback(
+    async (id: string, cut_day: number | null, due_day: number | null) =>
+      update(id, { cut_day, due_day }),
+    [update]
+  );
+  const attachAccount = useCallback(
+    async (id: string, account_id: string | null) => update(id, { account_id }),
+    [update]
+  );
 
-  // Mapa rápido por id (útil no UI)
-  const byId = useMemo(() => new Map(data.map(c => [c.id, c])), [data]);
+  const byId = useMemo(() => new Map(data.map((c) => [c.id, c])), [data]);
 
   return {
     data,
@@ -160,6 +188,6 @@ export function useCreditCards() {
     setLimit,
     setCutDue,
     attachAccount,
-    cycleFor, // exportamos helper puro para uso no UI
+    cycleFor,
   } as const;
 }


### PR DESCRIPTION
## Summary
- Type-safe account and credit card hooks with CRUD helpers returning created records
- SourcePicker now accepts SourceRef, supports inline creation for accounts/cards and auto-selects new entries
- TransactionsTable renders source badges with icons, tooltips, and card brands when available
- PageHeader component now supports optional children content

## Testing
- `npm run lint` *(fails: TabsContent is defined but never used, Unexpected any, Fast refresh only works when a file only exports components, etc.)*
- `npm run build` *(fails: Type 'Promise<void> | null' is not assignable to type 'void | Promise<void>', Module '@/components/PageHeader' has no exported member 'PageHeader', Property 'id' does not exist on type 'string', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689900cc0f7883228f6ad11fb79c712b