### PR TITLE
Finanças Mensal: KPIs/gráficos reativos + paleta estável

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,30 +1,47 @@
 // src/components/PageHeader.tsx
 import { ReactNode } from "react";
 
-type PageHeaderProps = {
+export type Breadcrumb = { label: string; href?: string };
+
+export type PageHeaderProps = {
   title: string;
   subtitle?: string;
   icon?: ReactNode;
   actions?: ReactNode;
+  breadcrumbs?: Breadcrumb[];
+  children?: ReactNode;
 };
 
-const PageHeader = ({ title, subtitle, icon, actions }: PageHeaderProps) => {
+export const PageHeader = ({ title, subtitle, icon, actions, breadcrumbs, children }: PageHeaderProps) => {
   return (
     <div className="mb-6 rounded-xl bg-gradient-to-r from-emerald-900 to-teal-700 text-white">
-      <div className="container mx-auto px-4 py-5 flex items-center justify-between gap-4">
-        <div className="flex items-center gap-3 min-w-0">
-          {icon ? <div className="rounded-lg bg-white/10 p-2 shrink-0">{icon}</div> : null}
-          <div className="min-w-0">
-            <h1 className="text-xl sm:text-2xl font-semibold truncate">{title}</h1>
-            {subtitle ? (
-              <p className="text-white/80 text-sm leading-relaxed truncate">{subtitle}</p>
-            ) : null}
+      <div className="container mx-auto px-4 py-5 flex flex-col gap-4">
+        {breadcrumbs && breadcrumbs.length ? (
+          <nav className="text-sm text-emerald-100/90">
+            {breadcrumbs.map((b, i) => (
+              <span key={i}>
+                {b.href ? <a href={b.href} className="hover:underline">{b.label}</a> : b.label}
+                {i < breadcrumbs.length - 1 ? ' / ' : ''}
+              </span>
+            ))}
+          </nav>
+        ) : null}
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex items-center gap-3 min-w-0">
+            {icon ? <div className="rounded-lg bg-white/10 p-2 shrink-0">{icon}</div> : null}
+            <div className="min-w-0">
+              <h1 className="text-xl sm:text-2xl font-semibold truncate">{title}</h1>
+              {subtitle ? (
+                <p className="text-white/80 text-sm leading-relaxed truncate">{subtitle}</p>
+              ) : null}
+            </div>
           </div>
+          {actions ? <div className="shrink-0">{actions}</div> : null}
         </div>
-        {actions ? <div className="shrink-0">{actions}</div> : null}
       </div>
+      {children ? <div className="container mx-auto px-4 pb-4">{children}</div> : null}
     </div>
   );
-}
+};
 
 export default PageHeader;

--- a/src/components/charts/DailyBars.tsx
+++ b/src/components/charts/DailyBars.tsx
@@ -1,5 +1,6 @@
 // src/components/charts/DailyBars.tsx
-import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend } from 'recharts';
+import { useMemo } from 'react';
+import { BarChart, Bar, XAxis, YAxis, Tooltip, ResponsiveContainer, Legend, LabelList } from 'recharts';
 import dayjs from 'dayjs';
 import { SERIES_COLORS } from '@/lib/palette';
 
@@ -7,28 +8,56 @@ type Tx = {
   date: string; value: number; type: 'income' | 'expense';
 };
 
-export default function DailyBars({ transacoes, mes }: { transacoes: Tx[]; mes: string }) {
+interface Props {
+  transacoes: Tx[];
+  mes: string;
+}
+
+export default function DailyBars({ transacoes, mes }: Props) {
   // cria série diária do mês: receitas e despesas
-  const daysInMonth = dayjs(mes + '-01').daysInMonth();
-  const data = Array.from({ length: daysInMonth }, (_, i) => {
-    const d = dayjs(mes + '-01').date(i + 1).format('YYYY-MM-DD');
-    const receitas = transacoes.filter(t => t.type === 'income' && t.date === d).reduce((s, t) => s + t.value, 0);
-    const despesas = transacoes.filter(t => t.type === 'expense' && t.date === d).reduce((s, t) => s + t.value, 0);
-    return { dia: i + 1, receitas, despesas };
-  });
+  const data = useMemo(() => {
+    const daysInMonth = dayjs(mes + '-01').daysInMonth();
+    return Array.from({ length: daysInMonth }, (_, i) => {
+      const d = dayjs(mes + '-01').date(i + 1).format('YYYY-MM-DD');
+      const receitas = transacoes
+        .filter(t => t.type === 'income' && t.date === d)
+        .reduce((s, t) => s + t.value, 0);
+      const despesas = transacoes
+        .filter(t => t.type === 'expense' && t.date === d)
+        .reduce((s, t) => s + t.value, 0);
+      return { dia: i + 1, receitas, despesas };
+    });
+  }, [transacoes, mes]);
 
   return (
     <div className="rounded-xl border bg-white dark:bg-slate-900 p-4">
       <h3 className="font-medium mb-3">Movimento diário</h3>
       <div className="h-[320px]">
         <ResponsiveContainer>
-          <BarChart data={data}>
+          <BarChart data={data} margin={{ top: 20, right: 20, bottom: 0, left: 20 }}>
             <XAxis dataKey="dia" />
-            <YAxis />
-            <Tooltip formatter={(v: any) => `R$ ${Number(v).toFixed(2)}`} />
+            <YAxis tickFormatter={(v: number) => `R$ ${v}`} />
+            <Tooltip
+              formatter={(v: number) => `R$ ${v.toFixed(2)}`}
+              labelFormatter={(l: number) => `Dia ${l}`}
+            />
             <Legend />
-            <Bar dataKey="despesas" name="Despesas" fill={SERIES_COLORS.expense} />
-            <Bar dataKey="receitas" name="Receitas" fill={SERIES_COLORS.income} />
+            <Bar
+              dataKey="despesas"
+              name="Despesas"
+              fill={SERIES_COLORS.expense}
+              radius={[4, 4, 0, 0]}
+            >
+              <LabelList position="top" formatter={(v: number) => (v ? `R$ ${v}` : '')} />
+            </Bar>
+            <Bar
+              dataKey="receitas"
+              name="Receitas"
+              fill={SERIES_COLORS.income}
+              radius={[4, 4, 0, 0]}
+            >
+              <LabelList position="top" formatter={(v: number) => (v ? `R$ ${v}` : '')} />
+            </Bar>
           </BarChart>
         </ResponsiveContainer>
       </div>

--- a/src/lib/palette.ts
+++ b/src/lib/palette.ts
@@ -19,10 +19,12 @@ export const SERIES_COLORS = {
   expense: '#ef4444', // red-500
 };
 
-export function colorForCategory(name: string): string {
-  if (!name) return '#94a3b8';
-  const fixed = CATEGORY_COLORS[name];
-  return fixed ?? hashToColor(name);
+// Map category name or id to a deterministic color
+export function mapCategoryColor(input: string | number): string {
+  const key = String(input);
+  if (!key) return '#94a3b8';
+  const fixed = CATEGORY_COLORS[key];
+  return fixed ?? hashToColor(key);
 }
 
 function hashToColor(input: string) {


### PR DESCRIPTION
## Summary
- Type charts and Finanças page, removing `any` casts and unused imports
- Add deterministic category color hashing and breadcrumb-aware PageHeader
- Feed filtered transactions into reactive charts and KPIs

## Testing
- `npx eslint src/components/charts/CategoryDonut.tsx src/components/charts/DailyBars.tsx src/lib/palette.ts src/pages/FinancasMensal.tsx src/components/PageHeader.tsx`
- `npm run build` *(fails: TS errors in unrelated pages and hooks)*

------
https://chatgpt.com/codex/tasks/task_e_6899011fd99c83228d6ef5b3ed5cddfe