### PR TITLE
fix: alias conflicting type imports

### DIFF
--- a/src/components/SourcePicker.tsx
+++ b/src/components/SourcePicker.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { toast } from "sonner";
 
-import type { CreditCard as CardModel } from "@/hooks/useCreditCards";
+import type { CreditCard as TCreditCard } from "@/hooks/useCreditCards";
 
 export type SourceValue = { kind: "account" | "card"; id: string | null };
 
@@ -52,7 +52,7 @@ export default function SourcePicker({
 
   const cardHint = useMemo(() => {
     if (!showCardHints || kind !== "card" || !selectedId) return null;
-    const cc: CardModel | undefined = cardsById.get(selectedId);
+    const cc: TCreditCard | undefined = cardsById.get(selectedId);
     if (!cc) return null;
     const cyc = cardCycleFor(cc);
     if (!cyc) return null;

--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -15,13 +15,13 @@ import { toast } from 'sonner';
 import { useAccounts } from '@/hooks/useAccounts';
 import { useCreditCards } from '@/hooks/useCreditCards';
 import type { Account } from '@/hooks/useAccounts';
-import type { CreditCard } from '@/hooks/useCreditCards';
+import type { CreditCard as TCreditCard } from '@/hooks/useCreditCards';
 import { Badge } from '@/components/ui/badge';
 
 // Tipo de linha exibida na tabela (shape de UI vindo de FinancasMensal)
 type SourceRef =
   | { kind: 'account'; id: string; entity?: Account }
-  | { kind: 'card'; id: string; entity?: CreditCard };
+  | { kind: 'card'; id: string; entity?: TCreditCard };
 
 export type UITransaction = {
   id: number;


### PR DESCRIPTION
## Summary
- alias duplicated `CreditCard` types as `TCreditCard` to avoid name conflicts with values

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: TypeScript errors unrelated to changes)*

------
https://chatgpt.com/codex/tasks/task_e_689a1ea538a88322957a0b3c3b5d7895