### PR TITLE
Finanças — Anual (v1)

### DIFF
--- a/src/components/charts/CategoryDonut.tsx
+++ b/src/components/charts/CategoryDonut.tsx
@@ -4,11 +4,18 @@ import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recha
 import { mapCategoryColor } from '@/lib/palette';
 import type { UITransaction } from '@/components/TransactionsTable';
 
-type Props = { transacoes?: UITransaction[]; mes?: string };
+type Props = {
+  transacoes?: UITransaction[];
+  mes?: string;
+  categoriesData?: Array<{ category: string; value: number }>;
+};
 
-export default function CategoryDonut({ transacoes = [] }: Props) {
+export default function CategoryDonut({ transacoes = [], categoriesData }: Props) {
   // soma por categoria (apenas despesas)
   const data = useMemo(() => {
+    if (categoriesData) {
+      return categoriesData.map((c) => ({ name: c.category, value: c.value }));
+    }
     const byCat = transacoes
       .filter((t) => t.type === 'expense')
       .reduce<Record<string, number>>((acc, t) => {
@@ -18,7 +25,7 @@ export default function CategoryDonut({ transacoes = [] }: Props) {
       }, {});
 
     return Object.entries(byCat).map(([name, value]) => ({ name, value }));
-  }, [transacoes]);
+  }, [categoriesData, transacoes]);
 
   if (!data.length) {
     return (
@@ -49,7 +56,12 @@ export default function CategoryDonut({ transacoes = [] }: Props) {
                 ))}
               </Pie>
             <Tooltip
-              formatter={(v: number) => `R$ ${v.toFixed(2)}`}
+              formatter={(v: number) =>
+                (Number(v) || 0).toLocaleString('pt-BR', {
+                  style: 'currency',
+                  currency: 'BRL',
+                })
+              }
               labelFormatter={(name: string) => name}
             />
             <Legend />

--- a/src/pages/FinancasAnual.tsx
+++ b/src/pages/FinancasAnual.tsx
@@ -5,18 +5,14 @@ import 'dayjs/locale/pt-br';
 import PageHeader from '@/components/PageHeader';
 import { MotionCard } from '@/components/ui/MotionCard';
 import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
-import { Coins, TrendingUp, TrendingDown } from 'lucide-react';
+import { Coins, TrendingUp, TrendingDown, CalendarRange } from 'lucide-react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import CategoryDonut from '@/components/charts/CategoryDonut';
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
 import { Button } from '@/components/ui/button';
 import { Link } from 'react-router-dom';
 import { useCategories } from '@/hooks/useCategories';
-import {
-  getYearSummary,
-  type YearSummary,
-  type Transaction,
-} from '@/hooks/useTransactions';
+import { getYearSummary, type YearSummary } from '@/hooks/useTransactions';
 import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip } from 'recharts';
 
 dayjs.locale('pt-br');
@@ -48,9 +44,27 @@ export default function FinancasAnual() {
   const { byId: categoriasById } = useCategories();
 
   const kpis = useMemo(() => {
-    if (!summary) return { income: 0, expense: 0, balance: 0 };
-    return summary.totals;
+    if (!summary)
+      return { income: 0, expense: 0, balance: 0 };
+    return {
+      income: Number(summary.totalIncome) || 0,
+      expense: Number(summary.totalExpense) || 0,
+      balance: Number(summary.totalBalance) || 0,
+    };
   }, [summary]);
+
+  const worstMonth = useMemo(() => {
+    if (!summary) return null;
+    const nonZero = summary.months.filter((m) => (Number(m.expense) || 0) > 0);
+    if (!nonZero.length) return null;
+    return nonZero.reduce((max, m) => (m.expense > max.expense ? m : max));
+  }, [summary]);
+
+  const worstLabel = useMemo(() => {
+    if (!worstMonth) return '';
+    const mes = dayjs(`${year}-${String(worstMonth.month).padStart(2, '0')}-01`).format('MMMM');
+    return mes.charAt(0).toUpperCase() + mes.slice(1);
+  }, [worstMonth, year]);
 
   const curveData = useMemo(() => {
     if (!summary) return [] as { mes: string; saldo: number }[];
@@ -65,36 +79,25 @@ export default function FinancasAnual() {
     });
   }, [summary, year]);
 
-  type DonutTx = Pick<Transaction, 'id' | 'date' | 'description'> & {
-    value: number;
-    type: 'expense';
-    category: string;
-  };
-  const donutTx = useMemo<DonutTx[]>(() => {
-    if (!summary) return [];
-    return summary.byCategory
-      .filter((v) => v.total > 0)
-      .map((v, idx) => ({
-        id: idx,
-        date: '',
-        description: '',
-        value: v.total,
-        type: 'expense',
-        category:
-          v.category_id === null
-            ? 'Sem categoria'
-            : categoriasById.get(v.category_id)?.name ?? 'Sem categoria',
-      }));
+  const categoriesData = useMemo(() => {
+    if (!summary) return [] as { category: string; value: number }[];
+    const agg: Record<string, number> = {};
+    summary.months.forEach((m) => {
+      Object.entries(m.byCategory).forEach(([cat, val]) => {
+        agg[cat] = (agg[cat] ?? 0) + (Number(val) || 0);
+      });
+    });
+    return Object.entries(agg).map(([catId, value]) => ({
+      category:
+        catId === 'null'
+          ? 'Sem categoria'
+          : categoriasById.get(catId)?.name ?? 'Sem categoria',
+      value,
+    }));
   }, [summary, categoriasById]);
 
-  type MonthRow = {
-    month: number;
-    income: number;
-    expense: number;
-    balance: number;
-  };
-  const monthsTable = useMemo<MonthRow[]>(() => {
-    if (!summary) return [];
+  const monthsTable = useMemo(() => {
+    if (!summary) return [] as YearSummary['months'];
     return summary.months;
   }, [summary]);
 
@@ -119,12 +122,17 @@ export default function FinancasAnual() {
                 </SelectContent>
               </Select>
             </div>
+            <div className="sm:col-span-1">
+              <Button asChild>
+                <Link to="/financas/mensal">Ver Mensal</Link>
+              </Button>
+            </div>
           </div>
         )}
       />
 
       {/* KPIs */}
-      <section className="grid gap-4 sm:grid-cols-3">
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <MotionCard>
           <div className="flex items-center gap-3">
             <div className="p-2 rounded-full bg-blue-600 text-white">
@@ -160,6 +168,19 @@ export default function FinancasAnual() {
             </div>
           </div>
         </MotionCard>
+
+        <MotionCard>
+          <div className="flex items-center gap-3">
+            <div className="p-2 rounded-full bg-amber-500 text-white">
+              <CalendarRange size={18} />
+            </div>
+            <div className="flex flex-col">
+              <span className="text-sm text-slate-500 dark:text-slate-300">Mês com maior despesa</span>
+              <AnimatedNumber value={worstMonth?.expense || 0} />
+              <span className="text-xs text-slate-500 dark:text-slate-300">{worstLabel || '—'}</span>
+            </div>
+          </div>
+        </MotionCard>
       </section>
 
       {/* Gráficos */}
@@ -172,7 +193,14 @@ export default function FinancasAnual() {
                 <AreaChart data={curveData}>
                   <XAxis dataKey="mes" />
                   <YAxis />
-                  <Tooltip formatter={(v: number) => `R$ ${Number(v).toFixed(2)}`} />
+                  <Tooltip
+                    formatter={(v: number) =>
+                      (Number(v) || 0).toLocaleString('pt-BR', {
+                        style: 'currency',
+                        currency: 'BRL',
+                      })
+                    }
+                  />
                   <Area type="monotone" dataKey="saldo" stroke="#10b981" fill="#10b98133" />
                 </AreaChart>
               </ResponsiveContainer>
@@ -180,7 +208,7 @@ export default function FinancasAnual() {
           </div>
         </div>
         <div className="lg:col-span-1">
-          <CategoryDonut transacoes={donutTx} />
+          <CategoryDonut categoriesData={categoriesData} />
         </div>
       </section>
 
@@ -208,13 +236,13 @@ export default function FinancasAnual() {
                 <TableRow key={m.month}>
                   <TableCell>{label}</TableCell>
                   <TableCell className="text-right">
-                    {m.income.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
+                    {(Number(m.income) || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
                   </TableCell>
                   <TableCell className="text-right">
-                    {m.expense.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
+                    {(Number(m.expense) || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
                   </TableCell>
                   <TableCell className="text-right">
-                    {m.balance.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
+                    {(Number(m.balance) || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
                   </TableCell>
                   <TableCell className="text-right">
                     <Button asChild size="sm" variant="outline">


### PR DESCRIPTION
## Summary
- implement yearly transactions summary hook and aggregation helper
- build annual finances page with selector, KPIs, charts, and monthly table
- extend category donut chart to accept pre-aggregated data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: TS6133 React unused, TS2345 etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689a596a4c748322b0e2244946368cad