### PR TITLE
feat: add design tokens

### DIFF
--- a/src/components/ui/MotionCard.tsx
+++ b/src/components/ui/MotionCard.tsx
@@ -4,7 +4,7 @@ import type { ReactNode } from 'react';
 export function MotionCard({ children, className='' }:{children:ReactNode; className?:string}) {
   return (
     <motion.div
-      className={`bg-white dark:bg-slate-800 rounded-card shadow-card p-6 ${className}`}
+      className={`bg-[var(--color-surface)] rounded-[var(--radius-card)] shadow-[var(--shadow-card)] p-6 ${className}`}
       initial={{ y: 10, opacity: 0 }} animate={{ y: 0, opacity: 1 }}
       transition={{ duration: .3 }}
       whileHover={{ y: -3, scale: 1.01 }}

--- a/src/index.css
+++ b/src/index.css
@@ -7,9 +7,43 @@
 @tailwind components;
 @tailwind utilities;
 
+/* Design tokens */
+:root {
+  /* Colors */
+  --color-primary: #009579;
+  --color-secondary: #1E88E5;
+  --color-neutral: #64748b;
+  --color-success: #22c55e;
+  --color-warning: #f6be23;
+  --color-error: #ff4f5a;
+  --color-surface: #ffffff;
+
+  /* Typography */
+  --font-sans: "Inter Variable", ui-sans-serif, system-ui, -apple-system,
+    "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  --font-display: "Sora Variable", var(--font-sans);
+
+  /* Spacing */
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+
+  /* Borders */
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 1rem;
+  --radius-card: 1.75rem;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
+  --shadow-md: 0 4px 6px rgba(0,0,0,0.1);
+  --shadow-card: 0 8px 20px rgba(0,0,0,0.08);
+}
+
 /* Preferência de tema */
 :root { color-scheme: light; }
-.dark { color-scheme: dark; }
+.dark { color-scheme: dark; --color-surface: #1e293b; }
 
 /* Tokens (mantém compatível com shadcn) */
 @layer base {

--- a/src/lib/palette.ts
+++ b/src/lib/palette.ts
@@ -1,6 +1,23 @@
 // src/lib/palette.ts
 // Cores fixas por categoria + helpers
 
+export type PaletteCategory =
+  | 'primary'
+  | 'secondary'
+  | 'neutral'
+  | 'success'
+  | 'warning'
+  | 'error';
+
+export const PALETTE: Record<PaletteCategory, string> = {
+  primary: 'var(--color-primary)',
+  secondary: 'var(--color-secondary)',
+  neutral: 'var(--color-neutral)',
+  success: 'var(--color-success)',
+  warning: 'var(--color-warning)',
+  error: 'var(--color-error)',
+};
+
 export const CATEGORY_COLORS: Record<string, string> = {
   'Alimentação': '#22c55e',   // emerald-500
   'Transporte':  '#f97316',   // orange-500


### PR DESCRIPTION
## Summary
- define global design tokens for colors, typography, spacing, borders and shadows
- map token colors in a typed palette utility
- refactor MotionCard to use CSS variable tokens for styling

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find name 'colorForCategory', plus other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_689a5a2fe97c8322951d143ff8eddeb0