### PR TITLE
feat: add global error boundary and toast helpers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.62.0",
+        "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.30.1",
         "recharts": "^3.1.2",
@@ -3546,7 +3547,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/d3-array": {
@@ -4337,6 +4337,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.16.tgz",
+      "integrity": "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/graphemer": {
@@ -5290,6 +5299,23 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.5.2.tgz",
+      "integrity": "sha512-Tun3BbCxzmXXM7C+NI4qiv6lT0uwGh4oAfeJyNOjYUejTsm35mK9iCaYLGv8cBz9L5YxZLx/2ii7zsIwPtPUdw==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-icons": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.62.0",
+    "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.30.1",
     "recharts": "^3.1.2",

--- a/src/components/AppErrorBoundary.tsx
+++ b/src/components/AppErrorBoundary.tsx
@@ -1,0 +1,53 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error?: Error;
+}
+
+/**
+ * Global error boundary with themed fallback UI.
+ */
+export default class AppErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error('Uncaught error:', error, errorInfo);
+  }
+
+  handleReload = () => {
+    this.setState({ hasError: false, error: undefined });
+    window.location.reload();
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div className="flex h-screen flex-col items-center justify-center gap-4 bg-background p-6 text-center text-foreground">
+          <h1 className="text-2xl font-bold">Algo deu errado</h1>
+          {this.state.error && (
+            <p className="text-sm text-muted-foreground">
+              {this.state.error.message}
+            </p>
+          )}
+          <button
+            onClick={this.handleReload}
+            className="rounded-md bg-primary px-4 py-2 text-primary-foreground hover:bg-primary/90"
+          >
+            Recarregar
+          </button>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/src/components/ui/Toasts.ts
+++ b/src/components/ui/Toasts.ts
@@ -1,0 +1,28 @@
+import { createElement } from 'react';
+import toast, { Toaster, type ToastOptions } from 'react-hot-toast';
+import { CheckCircle2, XCircle } from 'lucide-react';
+
+const baseOptions: ToastOptions = {
+  position: 'top-right',
+  style: {
+    background: 'hsl(var(--background))',
+    color: 'hsl(var(--foreground))',
+    border: '1px solid hsl(var(--border))',
+  },
+};
+
+export const toastSuccess = (message: string, options?: ToastOptions) =>
+  toast.success(message, {
+    icon: createElement(CheckCircle2, { className: 'text-green-600' }),
+    ...baseOptions,
+    ...options,
+  });
+
+export const toastError = (message: string, options?: ToastOptions) =>
+  toast.error(message, {
+    icon: createElement(XCircle, { className: 'text-red-600' }),
+    ...baseOptions,
+    ...options,
+  });
+
+export { Toaster };

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,16 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import AppErrorBoundary from './components/AppErrorBoundary'
+import { Toaster } from './components/ui/Toasts'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <AppErrorBoundary>
+      <>
+        <App />
+        <Toaster />
+      </>
+    </AppErrorBoundary>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- add global AppErrorBoundary with themed fallback
- centralize toast helpers using react-hot-toast
- wrap app with error boundary and toaster in entry point

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689a5a46896c8322a225ab2fde1c3e19