### PR TITLE
feat: add global navigation hotkeys

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,6 +44,8 @@ export default function App() {
         <PeriodProvider>
           {/* Toaster global */}
           <Toaster richColors position="top-right" />
+          {/* Atalhos globais */}
+          <AppHotkeys />
           <AppRoutes />
         </PeriodProvider>
       </Router>
@@ -62,9 +64,6 @@ function AppRoutes() {
     <div className="flex min-h-screen">
       <Sidebar />
       <main className="flex-1 p-6">
-        {/* ⬇️ Atalhos globais (g d, g f, g i, g m, g c, Shift+/? para ajuda) */}
-        <AppHotkeys />
-
         <Suspense fallback={<p>Carregando…</p>}>
           <Routes>
             {/* redirect raiz */}

--- a/src/components/AppHotkeys.tsx
+++ b/src/components/AppHotkeys.tsx
@@ -17,23 +17,53 @@ export function AppHotkeys() {
 
   React.useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target?.closest('input, textarea, select, [contenteditable="true"]')) return;
+
       // Ajuda
       if (e.shiftKey && e.key === "?") {
         e.preventDefault();
         toast.message("Atalhos", {
           description:
-            "g d: Dashboard • g f: Finanças • g i: Investimentos • g m: Metas • g c: Configurações",
+            "N: nova transação • /: buscar • F: Finanças • M: Milhas • g d: Dashboard • g f: Finanças • g i: Investimentos • g m: Metas • g c: Configurações",
         });
         return;
       }
+
+      const key = e.key.toLowerCase();
+
+      // atalhos diretos (sem aguardando 'g')
+      if (!awaiting && !e.ctrlKey && !e.metaKey && !e.altKey) {
+        if (key === 'f') {
+          e.preventDefault();
+          nav('/financas/mensal');
+          return;
+        }
+        if (key === 'm') {
+          e.preventDefault();
+          nav('/milhas/livelo');
+          return;
+        }
+        if (key === 'n') {
+          e.preventDefault();
+          window.dispatchEvent(new CustomEvent('nova-transacao'));
+          return;
+        }
+        if (e.key === '/') {
+          e.preventDefault();
+          window.dispatchEvent(new CustomEvent('global-search'));
+          return;
+        }
+      }
+
       // Sequência "g" + letra
-      if (!awaiting && e.key.toLowerCase() === "g") {
+      if (!awaiting && key === "g") {
         setAwaiting(true);
         timer.current = window.setTimeout(() => setAwaiting(false), 1200) as unknown as number;
         return;
       }
       if (awaiting) {
-        const path = map[e.key.toLowerCase()];
+        const path = map[key];
         if (path) {
           e.preventDefault();
           if (timer.current) window.clearTimeout(timer.current);


### PR DESCRIPTION
## Summary
- add global keyboard shortcuts for new transaction, search, and quick navigation
- mount AppHotkeys at app root for consistent listener

## Testing
- `npm run lint`
- `npm run build` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_689a5a525af483228af8dd1d7f7e99b1