### PR TITLE
feat: add codemod for import aliases

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "postcss": "^8.5.6",
         "supabase": "^2.33.9",
         "tailwindcss": "^3.4.17",
+        "tsx": "^4.20.3",
         "typescript": "~5.8.3",
         "typescript-eslint": "^8.39.0",
         "vite": "^7.1.0"
@@ -4270,6 +4271,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/get-tsconfig": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.10.1.tgz",
+      "integrity": "sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
     "node_modules/glob": {
       "version": "10.4.5",
       "resolved": "https://registry.npmjs.org/glob/-/glob-10.4.5.tgz",
@@ -5551,6 +5565,16 @@
         "node": ">=4"
       }
     },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
@@ -6072,6 +6096,26 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
+    },
+    "node_modules/tsx": {
+      "version": "4.20.3",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.20.3.tgz",
+      "integrity": "sha512-qjbnuR9Tr+FJOMBqJCW5ehvIo/buZq7vH7qD7JziU98h6l3qGy0a/yPFjwO+y0/T7GFpNgNAvEcPPVfyT8rrPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.25.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "codemod:imports": "tsx scripts/codemod-rewrite-imports.ts",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -57,6 +58,7 @@
     "postcss": "^8.5.6",
     "supabase": "^2.33.9",
     "tailwindcss": "^3.4.17",
+    "tsx": "^4.20.3",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.0",
     "vite": "^7.1.0"

--- a/scripts/codemod-rewrite-imports.ts
+++ b/scripts/codemod-rewrite-imports.ts
@@ -1,0 +1,81 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import ts from 'typescript'
+
+const DRY_RUN = process.argv.includes('--dry-run')
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const SRC_DIR = path.resolve(__dirname, '../src')
+const IGNORED = new Set(['node_modules', 'supabase', 'public', 'backups'])
+
+async function collectFiles(dir: string): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  const files: string[] = []
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (IGNORED.has(entry.name)) continue
+      files.push(...(await collectFiles(path.join(dir, entry.name))))
+    } else if (entry.isFile()) {
+      if (/\.tsx?$/.test(entry.name)) files.push(path.join(dir, entry.name))
+    }
+  }
+  return files
+}
+
+function rewriteImports(filePath: string, sourceText: string) {
+  const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true)
+  const edits: { start: number; end: number; text: string; old: string }[] = []
+  function visit(node: ts.Node) {
+    if (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) {
+      if (node.moduleSpecifier && ts.isStringLiteral(node.moduleSpecifier)) {
+        const spec = node.moduleSpecifier
+        const value = spec.text
+        if (value.startsWith('..')) {
+          const absolute = path.resolve(path.dirname(filePath), value)
+          const rel = path.relative(SRC_DIR, absolute)
+          if (!rel.startsWith('..')) {
+            const newPath = '@/' + rel.replace(/\\/g, '/')
+            edits.push({
+              start: spec.getStart() + 1,
+              end: spec.getEnd() - 1,
+              text: newPath,
+              old: value,
+            })
+          }
+        }
+      }
+    }
+    ts.forEachChild(node, visit)
+  }
+  visit(sourceFile)
+  if (edits.length === 0) return null
+  let updated = sourceText
+  for (const edit of edits.sort((a, b) => b.start - a.start)) {
+    updated = updated.slice(0, edit.start) + edit.text + updated.slice(edit.end)
+  }
+  return { updated, edits }
+}
+
+async function main() {
+  const files = await collectFiles(SRC_DIR)
+  for (const file of files) {
+    const text = await fs.readFile(file, 'utf8')
+    const result = rewriteImports(file, text)
+    if (result) {
+      for (const edit of result.edits) {
+        console.log(`${file}: '${edit.old}' -> '${edit.text}'`)
+      }
+      if (!DRY_RUN) {
+        await fs.writeFile(file, result.updated)
+      }
+    }
+  }
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,13 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
-import path from 'path'
+import { fileURLToPath, URL } from 'node:url'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, 'src'),
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
 })


### PR DESCRIPTION
## Summary
- add script to rewrite relative imports to `@/` alias
- expose `codemod:imports` npm script and `tsx` dev dependency
- configure Vite to resolve `@` via `fileURLToPath`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: existing TypeScript errors)*
- `npm run codemod:imports -- --dry-run`


------
https://chatgpt.com/codex/tasks/task_e_689a5c0214b08322a3d85b9c699cc96f