### PR TITLE
feat: scaffold bills page with ICS export

### DIFF
--- a/src/hooks/useBills.ts
+++ b/src/hooks/useBills.ts
@@ -41,3 +41,18 @@ export function useBills(year: number, month: number) {
 
   return { data, loading, list, markPaid };
 }
+
+export async function getUpcoming(month: number, year: number) {
+  const monthStart = new Date(year, month - 1, 1).toISOString().slice(0, 10);
+  const monthEnd = new Date(year, month, 0).toISOString().slice(0, 10);
+  const today = new Date().toISOString().slice(0, 10);
+  const start = today > monthStart ? today : monthStart;
+  const { data, error } = await supabase
+    .from("bills")
+    .select("*")
+    .gte("due_date", start)
+    .lte("due_date", monthEnd)
+    .order("due_date", { ascending: true });
+  if (error) throw error;
+  return data as Bill[];
+}

--- a/src/lib/ics.ts
+++ b/src/lib/ics.ts
@@ -1,0 +1,53 @@
+// src/lib/ics.ts
+// Helper to build a single VEVENT block for ICS export
+
+export type IcsEvent = {
+  title: string;
+  description?: string;
+  start: Date | string;
+  end?: Date | string;
+  url?: string;
+};
+
+function formatDateTime(input: Date | string) {
+  const d = typeof input === "string" ? new Date(input) : input;
+  return d.toISOString().replace(/[-:]/g, "").split(".")[0] + "Z";
+}
+
+function formatDate(input: Date | string) {
+  const d = typeof input === "string" ? new Date(input) : input;
+  return d.toISOString().slice(0, 10).replace(/-/g, "");
+}
+
+function escapeText(text: string) {
+  return text.replace(/\\n/g, "\\n").replace(/,/g, "\\,").replace(/;/g, "\\;");
+}
+
+export function buildSingleEvent({
+  title,
+  description = "",
+  start,
+  end,
+  url,
+}: IcsEvent): string {
+  const uid = `${Date.now()}-${Math.random().toString(36).slice(2)}@fy`;
+  const dtStamp = formatDateTime(new Date());
+  const lines = [
+    "BEGIN:VEVENT",
+    `UID:${uid}`,
+    `DTSTAMP:${dtStamp}`,
+    `SUMMARY:${escapeText(title)}`,
+    `DTSTART;VALUE=DATE:${formatDate(start)}`,
+  ];
+  if (end) {
+    lines.push(`DTEND;VALUE=DATE:${formatDate(end)}`);
+  }
+  if (description) {
+    lines.push(`DESCRIPTION:${escapeText(description)}`);
+  }
+  if (url) {
+    lines.push(`URL:${url}`);
+  }
+  lines.push("END:VEVENT");
+  return lines.join("\r\n");
+}

--- a/src/pages/Bills.tsx
+++ b/src/pages/Bills.tsx
@@ -1,0 +1,63 @@
+import { useMemo } from "react";
+import PageHeader from "@/components/PageHeader";
+import { Button } from "@/components/ui/button";
+import { usePeriod } from "@/state/periodFilter";
+import { useBills, getUpcoming } from "@/hooks/useBills";
+import { buildSingleEvent } from "@/lib/ics";
+
+export default function Bills() {
+  const { month, year } = usePeriod();
+  const { data, loading } = useBills(year, month);
+
+  const exportIcs = async () => {
+    const upcoming = await getUpcoming(month, year);
+    const events = upcoming.map((b) =>
+      buildSingleEvent({
+        title: b.description,
+        description: `Valor: R$ ${b.amount.toFixed(2)}`,
+        start: b.due_date,
+        end: b.due_date,
+      })
+    );
+    const ics = [
+      "BEGIN:VCALENDAR",
+      "VERSION:2.0",
+      "PRODID:-//fy//bills//PT-BR",
+      ...events,
+      "END:VCALENDAR",
+    ].join("\r\n");
+    const blob = new Blob([ics], { type: "text/calendar" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = "bills.ics";
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const list = useMemo(() => {
+    if (loading) return <p>Carregando…</p>;
+    if (!data.length) return <p>Nenhuma conta para este mês.</p>;
+    return (
+      <ul className="space-y-2">
+        {data.map((b) => (
+          <li key={b.id} className="flex justify-between rounded border p-2">
+            <span>{b.description}</span>
+            <span>{new Date(b.due_date).toLocaleDateString("pt-BR")}</span>
+          </li>
+        ))}
+      </ul>
+    );
+  }, [data, loading]);
+
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Contas do mês"
+        subtitle="Contas a pagar"
+        actions={<Button onClick={exportIcs}>Exportar .ics</Button>}
+      />
+      {list}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add getUpcoming to useBills for upcoming bills
- introduce buildSingleEvent helper for ICS events
- scaffold Bills page with export to .ics

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a5c56f78c8322a4376f8898ebb272