### PR TITLE
feat: add receipt upload component and OCR stub

### DIFF
--- a/src/components/ReceiptUpload.tsx
+++ b/src/components/ReceiptUpload.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { useReceiptOCR, type ReceiptData } from "@/hooks/useReceiptOCR";
+
+type Props = {
+  onExtract: (data: ReceiptData) => void;
+};
+
+export default function ReceiptUpload({ onExtract }: Props) {
+  const [file, setFile] = useState<File | null>(null);
+  const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const { parse } = useReceiptOCR();
+
+  useEffect(() => {
+    return () => {
+      if (previewUrl) URL.revokeObjectURL(previewUrl);
+    };
+  }, [previewUrl]);
+
+  const onFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0] ?? null;
+    if (previewUrl) URL.revokeObjectURL(previewUrl);
+    setFile(f);
+    setPreviewUrl(f ? URL.createObjectURL(f) : null);
+  };
+
+  const extract = async () => {
+    if (!file) return;
+    const data = await parse(file);
+    onExtract(data);
+  };
+
+  return (
+    <div className="flex flex-col gap-4">
+      <input type="file" accept="image/*,application/pdf" onChange={onFileChange} />
+      {previewUrl && (
+        <div className="max-w-xs">
+          {file?.type === "application/pdf" ? (
+            <iframe src={previewUrl} className="h-64 w-full" title="Preview" />
+          ) : (
+            <img src={previewUrl} alt="Preview" className="h-64 w-full object-contain" />
+          )}
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={extract}
+        disabled={!file}
+        className="rounded bg-emerald-600 px-4 py-2 text-white disabled:opacity-50"
+      >
+        Extrair dados
+      </button>
+    </div>
+  );
+}
+

--- a/src/hooks/useReceiptOCR.ts
+++ b/src/hooks/useReceiptOCR.ts
@@ -1,0 +1,22 @@
+import { useCallback } from "react";
+
+export type ReceiptData = {
+  description: string;
+  value: number;
+  date: string;
+};
+
+export function useReceiptOCR() {
+  const parse = useCallback(async (file: File): Promise<ReceiptData> => {
+    void file;
+    // Stub: return simulated data
+    return {
+      description: "Compra Mercado X",
+      value: 123.45,
+      date: "2025-08-11",
+    };
+  }, []);
+
+  return { parse };
+}
+


### PR DESCRIPTION
## Summary
- add `ReceiptUpload` component with file input, preview, and extraction button
- add `useReceiptOCR` hook returning stubbed receipt data

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a5c85f6688322b07ed1f5b6694f6d