### PR TITLE
feat(a11y): improve accessibility basics

### DIFF
--- a/src/components/CategoryPicker.tsx
+++ b/src/components/CategoryPicker.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from "react";
+import { useMemo, useState, useId } from "react";
 import { Plus, Pencil, Trash2, X } from "lucide-react";
 import {
   Select,
@@ -53,6 +53,10 @@ export default function CategoryPicker({
   const [parentId, setParentId] = useState<string | null>(null);
   const [name, setName] = useState("");
   const [color, setColor] = useState<string | null>(null);
+
+  const nameId = useId();
+  const colorId = useId();
+  const colorHexId = useId();
 
   function openCreate(pId: string | null) {
     setMode("create");
@@ -160,6 +164,7 @@ export default function CategoryPicker({
           variant="outline"
           size="icon"
           title="Nova categoria"
+          aria-label="Nova categoria"
           onClick={() =>
             onRequestCreate ? onRequestCreate() : openCreate(null)
           }
@@ -175,6 +180,7 @@ export default function CategoryPicker({
             variant="outline"
             size="icon"
             title="Nova subcategoria"
+            aria-label="Nova subcategoria"
             onClick={() => openCreate(value)}
           >
             <Plus className="h-4 w-4" />
@@ -184,6 +190,7 @@ export default function CategoryPicker({
             variant="outline"
             size="icon"
             title="Editar"
+            aria-label="Editar"
             onClick={() => openEdit(value)}
           >
             <Pencil className="h-4 w-4" />
@@ -193,6 +200,7 @@ export default function CategoryPicker({
             variant="outline"
             size="icon"
             title="Excluir"
+            aria-label="Excluir"
             onClick={() => handleDeleteDirect(value)}
           >
             <Trash2 className="h-4 w-4" />
@@ -206,6 +214,7 @@ export default function CategoryPicker({
           variant="outline"
           size="icon"
           title="Limpar seleção"
+          aria-label="Limpar seleção"
           onClick={() => onChange(null)}
         >
           <X className="h-4 w-4" />
@@ -226,23 +235,27 @@ export default function CategoryPicker({
 
           <div className="grid gap-3 py-2">
             <div className="grid gap-1">
-              <Label>Nome</Label>
+              <Label htmlFor={nameId}>Nome</Label>
               <Input
+                id={nameId}
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 placeholder="Ex.: Streaming"
               />
             </div>
             <div className="grid gap-1">
-              <Label>Cor (opcional)</Label>
+              <Label htmlFor={colorId}>Cor (opcional)</Label>
               <div className="flex items-center gap-3">
                 <input
+                  id={colorId}
                   type="color"
                   value={color ?? "#10B981"}
                   onChange={(e) => setColor(e.target.value)}
                   className="h-9 w-12 rounded"
                 />
                 <Input
+                  id={colorHexId}
+                  aria-label="Código da cor"
                   value={color ?? ""}
                   onChange={(e) => setColor(e.target.value)}
                   placeholder="#RRGGBB"

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -175,6 +175,7 @@ export function Sidebar() {
                         ].join(" ")}
                         aria-expanded={isOpen}
                         title={collapsed ? item.label : undefined}
+                        aria-label={collapsed ? item.label : undefined}
                       >
                         <span className="flex items-center gap-3">
                           <Icon className="h-4 w-4 text-slate-400 group-hover:text-white" />
@@ -239,6 +240,7 @@ function NavLeafLink({ leaf, collapsed }: { leaf: NavLeaf; collapsed?: boolean }
     <NavLink
       to={leaf.to}
       title={collapsed ? leaf.label : leaf.title}
+      aria-label={collapsed ? leaf.label : undefined}
       className={({ isActive }) =>
         [
           "group relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition",

--- a/src/components/SourcePicker.tsx
+++ b/src/components/SourcePicker.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState, useId } from "react";
 import { useAccounts } from "@/hooks/useAccounts";
 import { useCreditCards, cycleFor as cardCycleFor } from "@/hooks/useCreditCards";
 import { Wallet, CreditCard, Plus } from "lucide-react";
@@ -39,6 +39,11 @@ export default function SourcePicker({
   const [cardBrand, setCardBrand] = useState("");
   const [savingAcc, setSavingAcc] = useState(false);
   const [savingCard, setSavingCard] = useState(false);
+
+  const accNameId = useId();
+  const accBankId = useId();
+  const cardNameId = useId();
+  const cardBrandId = useId();
 
   const [kind, setKind] = useState<SourceValue["kind"]>(value.kind);
   const selectedId = value.id;
@@ -160,12 +165,12 @@ export default function SourcePicker({
           </DialogHeader>
           <div className="grid gap-4 py-2">
             <div className="grid gap-1">
-              <Label>Nome</Label>
-              <Input value={accName} onChange={(e) => setAccName(e.target.value)} />
+              <Label htmlFor={accNameId}>Nome</Label>
+              <Input id={accNameId} value={accName} onChange={(e) => setAccName(e.target.value)} />
             </div>
             <div className="grid gap-1">
-              <Label>Banco (opcional)</Label>
-              <Input value={accBank} onChange={(e) => setAccBank(e.target.value)} />
+              <Label htmlFor={accBankId}>Banco (opcional)</Label>
+              <Input id={accBankId} value={accBank} onChange={(e) => setAccBank(e.target.value)} />
             </div>
           </div>
           <DialogFooter>
@@ -211,12 +216,12 @@ export default function SourcePicker({
           </DialogHeader>
           <div className="grid gap-4 py-2">
             <div className="grid gap-1">
-              <Label>Nome</Label>
-              <Input value={cardName} onChange={(e) => setCardName(e.target.value)} />
+              <Label htmlFor={cardNameId}>Nome</Label>
+              <Input id={cardNameId} value={cardName} onChange={(e) => setCardName(e.target.value)} />
             </div>
             <div className="grid gap-1">
-              <Label>Bandeira (opcional)</Label>
-              <Input value={cardBrand} onChange={(e) => setCardBrand(e.target.value)} placeholder="Visa, Mastercard..." />
+              <Label htmlFor={cardBrandId}>Bandeira (opcional)</Label>
+              <Input id={cardBrandId} value={cardBrand} onChange={(e) => setCardBrand(e.target.value)} placeholder="Visa, Mastercard..." />
             </div>
           </div>
           <DialogFooter>

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -14,19 +14,23 @@ const TooltipTrigger = TooltipPrimitive.Trigger
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
->(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Portal>
-    <TooltipPrimitive.Content
-      ref={ref}
-      sideOffset={sideOffset}
-      className={cn(
-        "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
-        className
-      )}
-      {...props}
-    />
-  </TooltipPrimitive.Portal>
-))
+>(({ className, sideOffset = 4, id, ...props }, ref) => {
+  const fallbackId = React.useId();
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        ref={ref}
+        sideOffset={sideOffset}
+        id={id ?? fallbackId}
+        className={cn(
+          "z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]",
+          className
+        )}
+        {...props}
+      />
+    </TooltipPrimitive.Portal>
+  );
+})
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 
 export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/index.css
+++ b/src/index.css
@@ -93,6 +93,11 @@
   html { font-family: var(--font-sans); }
   body { @apply bg-background text-foreground antialiased; }
   h1, h2, h3 { font-family: var(--font-display); letter-spacing: -0.02em; }
+  *:focus-visible {
+    outline: 2px solid hsl(var(--ring));
+    outline-offset: 2px;
+    box-shadow: 0 0 0 2px hsl(var(--ring)/0.4);
+  }
 }
 
 /* ==== Background artístico (sempre ATRÁS do conteúdo) ==== */


### PR DESCRIPTION
## Summary
- add consistent global `:focus-visible` outline and shadow
- label icon-only navigation and action buttons
- associate form labels and tooltip content with inputs for screen readers

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a5ca83d0c832294e5bc41ae03bdbc