### PR TITLE
feat: lazy load main routes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,12 +4,12 @@ import { Toaster } from 'sonner';
 
 /* ---------- Contexto de Autenticação ---------- */
 import { AuthProvider, useAuth } from './contexts/AuthContext';
-import Login from './pages/Login';
 
 /* ---------- Componentes ---------- */
 import { Sidebar } from './components/Sidebar';
 import { AppHotkeys } from "./components/AppHotkeys";
 import { PeriodProvider } from './state/periodFilter';
+import RouteLoader from './components/RouteLoader';
 
 /* ---------- lazy imports de páginas ---------- */
 const Dashboard      = lazy(() => import('./pages/Dashboard'));
@@ -34,6 +34,7 @@ const ListaDesejos = lazy(() => import('./pages/ListaDesejos'));
 const ListaCompras = lazy(() => import('./pages/ListaCompras'));
 
 const Configuracoes = lazy(() => import('./pages/Configuracoes'));
+const Login         = lazy(() => import('./pages/Login'));
 
 /* ────────────────────────────────────────────── */
 
@@ -55,7 +56,7 @@ export default function App() {
 function AppRoutes() {
   const { user, loading } = useAuth();
 
-  if (loading) return <p className="p-6">Carregando sessão…</p>;
+  if (loading) return <RouteLoader />;
   if (!user)   return <Login />;
 
   return (
@@ -65,7 +66,7 @@ function AppRoutes() {
         {/* ⬇️ Atalhos globais (g d, g f, g i, g m, g c, Shift+/? para ajuda) */}
         <AppHotkeys />
 
-        <Suspense fallback={<p>Carregando…</p>}>
+        <Suspense fallback={<RouteLoader />}>
           <Routes>
             {/* redirect raiz */}
             <Route path="/" element={<Navigate to="/dashboard" />} />

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,0 +1,36 @@
+import { Component, ReactNode } from 'react';
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: unknown, info: unknown) {
+    console.error(error, info);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback || (
+          <div className="p-6 text-red-500">Ocorreu um erro ao carregar a página.</div>
+        )
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/components/RouteLoader.tsx
+++ b/src/components/RouteLoader.tsx
@@ -1,0 +1,11 @@
+import { Loader2 } from 'lucide-react';
+
+export function RouteLoader() {
+  return (
+    <div className="flex h-full w-full items-center justify-center p-6">
+      <Loader2 className="h-6 w-6 animate-spin text-primary" />
+    </div>
+  );
+}
+
+export default RouteLoader;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import ErrorBoundary from './components/ErrorBoundary'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <ErrorBoundary>
+      <App />
+    </ErrorBoundary>
   </StrictMode>,
 )


### PR DESCRIPTION
## Summary
- enable lazy login route and route-level spinner fallback
- add minimal RouteLoader component
- wrap app in global ErrorBoundary to catch lazy errors

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a5cb7b6688322a350bafcdbd99933