### PR TITLE
fix: correct package.json syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "prepare": "husky",
-    "codemod:imports": "tsx scripts/codemod-rewrite-imports.ts",
+    "codemod:imports": "tsx scripts/codemod-rewrite-imports.ts"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.6",


### PR DESCRIPTION
## Summary
- fix package.json by adding missing comma after `preview` script and removing trailing comma after `codemod:imports`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Parsing error in `src/main.tsx`)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689a62fba7b48322a95d165be20d98b5