### PR TITLE
Fix StrictMode tag and lint errors

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,16 +1,9 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.tsx'
-import ErrorBoundary from './components/ErrorBoundary'
-
-createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <ErrorBoundary>
-      <App />
-    </ErrorBoundary>
-import AppErrorBoundary from './components/AppErrorBoundary'
-import { Toaster } from './components/ui/Toasts'
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import AppErrorBoundary from './components/AppErrorBoundary';
+import { Toaster } from './components/ui/Toasts';
+import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
@@ -20,5 +13,6 @@ createRoot(document.getElementById('root')!).render(
         <Toaster />
       </>
     </AppErrorBoundary>
-  </StrictMode>,
-)
+  </StrictMode>
+);
+


### PR DESCRIPTION
## Summary
- fix StrictMode usage in main entrypoint
- wrap app with error boundary and toaster

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689a668117248322a917e7ba3f669e24