### PR TITLE
fix: types and imports for build

### DIFF
--- a/src/components/BrandBadge.tsx
+++ b/src/components/BrandBadge.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 
 export type MilesBrand = 'livelo' | 'latampass' | 'azul';
 

--- a/src/components/BrandIcon.tsx
+++ b/src/components/BrandIcon.tsx
@@ -1,5 +1,4 @@
 // src/components/BrandIcon.tsx
-import * as React from "react";
 import { Icon } from "@iconify/react";
 import {
   Wifi,

--- a/src/components/CategoryPicker.tsx
+++ b/src/components/CategoryPicker.tsx
@@ -36,7 +36,7 @@ export default function CategoryPicker({
   onChange,
   placeholder = "Selecione a categoria",
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- API placeholder
-  kind = "all",
+  kind: _kind = "all",
   allowClear = true,
   allowCreate = false,
   onRequestCreate,

--- a/src/components/ErrorBoundary.tsx
+++ b/src/components/ErrorBoundary.tsx
@@ -1,4 +1,4 @@
-import { Component, ReactNode } from 'react';
+import { Component, type ReactNode } from 'react';
 
 interface ErrorBoundaryProps {
   children: ReactNode;

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -1,4 +1,3 @@
-import * as React from "react";
 
 type LogoProps = { size?: number; className?: string };
 

--- a/src/components/ModalCartao.tsx
+++ b/src/components/ModalCartao.tsx
@@ -1,6 +1,6 @@
 
 
-import React, { useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -112,7 +112,15 @@ export default function ModalCartao({ open, onClose, onCreated }: ModalCartaoPro
           <div className="grid sm:grid-cols-2 gap-4">
             <div className="grid gap-1">
               <Label>Limite (R$) — opcional</Label>
-              <Input type="number" step="0.01" inputMode="decimal" value={limitAmount as any} onChange={(e) => setLimitAmount(e.target.value)} />
+              <Input
+                type="number"
+                step="0.01"
+                inputMode="decimal"
+                value={limitAmount as any}
+                onChange={(e) =>
+                  setLimitAmount(e.target.value === "" ? "" : Number(e.target.value))
+                }
+              />
             </div>
             <div className="grid gap-1">
               <Label>Conta p/ débito da fatura (opcional)</Label>
@@ -131,11 +139,27 @@ export default function ModalCartao({ open, onClose, onCreated }: ModalCartaoPro
           <div className="grid sm:grid-cols-2 gap-4">
             <div className="grid gap-1">
               <Label>Dia de fechamento</Label>
-              <Input type="number" min={1} max={31} value={cutDay as any} onChange={(e) => setCutDay(e.target.value)} />
+              <Input
+                type="number"
+                min={1}
+                max={31}
+                value={cutDay as any}
+                onChange={(e) =>
+                  setCutDay(e.target.value === "" ? "" : Number(e.target.value))
+                }
+              />
             </div>
             <div className="grid gap-1">
               <Label>Dia de vencimento (opcional)</Label>
-              <Input type="number" min={1} max={31} value={dueDay as any} onChange={(e) => setDueDay(e.target.value)} />
+              <Input
+                type="number"
+                min={1}
+                max={31}
+                value={dueDay as any}
+                onChange={(e) =>
+                  setDueDay(e.target.value === "" ? "" : Number(e.target.value))
+                }
+              />
             </div>
           </div>
 

--- a/src/components/ModalConta.tsx
+++ b/src/components/ModalConta.tsx
@@ -47,12 +47,18 @@ export function ModalConta({ open, onOpenChange, onCreated }: ModalContaProps) {
     setErroNome(null);
     setLoading(true);
     try {
-      // O método pode ser create ou add, depende do hook
-      const res = await (create ? create : (async () => { throw new Error("Método create não encontrado"); }))({
-        nome,
-        tipo,
-        instituicao: instituicao || undefined,
-        moeda,
+      const res = await create({
+        name: nome,
+        type:
+          tipo === "Dinheiro"
+            ? "cash"
+            : tipo === "Banco"
+              ? "bank"
+              : tipo === "Carteira Digital"
+                ? "wallet"
+                : "other",
+        institution: instituicao || undefined,
+        currency: moeda,
       });
       // res pode ser id ou objeto com id
       const id = typeof res === "string" ? res : res?.id;

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -80,7 +80,7 @@ export function useCategories() {
     ): Promise<void> => {
       const upd: Partial<Omit<Category, "id">> = { ...patch };
       if (upd.name && upd.color === undefined) {
-        upd.color = colorForCategory(upd.name);
+        upd.color = mapCategoryColor(upd.name);
       }
       const { error } = await supabase
         .from("categories")

--- a/src/hooks/useInvestments.ts
+++ b/src/hooks/useInvestments.ts
@@ -52,7 +52,7 @@ export type UseInvestmentsParams = {
   q?: string;     // busca textual
 };
 
-function normalizeType(t?: InvestmentType | null): TypePt | "Outros" {
+function normalizeType(t?: string | null): TypePt | "Outros" {
   if (!t) return "Outros";
   const map: Record<string, TypePt> = {
     renda_fixa: "Renda fixa",
@@ -79,7 +79,7 @@ function monthBounds(month?: number, year?: number) {
 
 export function useInvestments(params: UseInvestmentsParams = {}) {
   const { month, year, type = "all", q } = params;
-  const typeStr = (type as string) ?? "";
+  const typeStr = typeof type === "string" ? type : "";
   const qStr = q ?? "";
 
   const [rows, setRows] = useState<Investment[]>([]);

--- a/src/sw.ts
+++ b/src/sw.ts
@@ -1,3 +1,8 @@
+/// <reference lib="webworker" />
+
+export {};
+declare const self: ServiceWorkerGlobalScope;
+
 const CACHE_NAME = 'static-cache-v1';
 const ASSETS = [
   '/',


### PR DESCRIPTION
## Summary
- clean up unused React imports and type-only ReactNode usage
- correct category, account and credit card component typings
- fix service worker and investment hooks typing issues

## Testing
- `npm run typecheck`
- `npm run build`
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_689a674349dc8322b0bbace831deeb1d