### PR TITLE
Add env validation and mock data scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "prepare": "husky",
     "codemod:imports": "tsx scripts/codemod-rewrite-imports.ts",
+    "validate:env": "tsx scripts/validate-env.ts",
+    "gen:mock": "tsx scripts/generate-mock.ts"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.6",

--- a/scripts/generate-mock.ts
+++ b/scripts/generate-mock.ts
@@ -1,0 +1,29 @@
+import { writeFileSync, mkdirSync } from 'node:fs'
+import { join } from 'node:path'
+
+const data = {
+  categories: [
+    { id: 1, name: 'Food' },
+    { id: 2, name: 'Salary' },
+  ],
+  transactions: [
+    {
+      id: 1,
+      categoryId: 1,
+      description: 'Lunch',
+      amount: -12.5,
+      date: new Date().toISOString(),
+    },
+    {
+      id: 2,
+      categoryId: 2,
+      description: 'Paycheck',
+      amount: 2500,
+      date: new Date().toISOString(),
+    },
+  ],
+}
+
+mkdirSync('.tmp', { recursive: true })
+writeFileSync(join('.tmp', 'mock.json'), JSON.stringify(data, null, 2))
+console.log('Mock data written to .tmp/mock.json')

--- a/scripts/validate-env.ts
+++ b/scripts/validate-env.ts
@@ -1,0 +1,10 @@
+const required = ['SUPABASE_URL', 'SUPABASE_ANON_KEY'] as const
+
+const missing = required.filter((key) => !process.env[key])
+
+if (missing.length > 0) {
+  console.error(`Missing environment variables: ${missing.join(', ')}`)
+  process.exit(1)
+}
+
+console.log('All required environment variables are set.')


### PR DESCRIPTION
## Summary
- add TypeScript script to check required environment variables
- add mock data generator script for transactions and categories
- expose `validate:env` and `gen:mock` npm scripts

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error: JSX element 'StrictMode' has no corresponding closing tag)*
- `npm run typecheck`
- `npm run validate:env` *(fails: Missing environment variables SUPABASE_URL, SUPABASE_ANON_KEY)*
- `SUPABASE_URL=foo SUPABASE_ANON_KEY=bar npm run validate:env`
- `npm run gen:mock`


------
https://chatgpt.com/codex/tasks/task_e_689a65576dac8322a303a041a8b7c69e