### PR TITLE
chore: add release notes generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,12 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
     "lint": "eslint .",
     "typecheck": "tsc --noEmit",
     "prepare": "husky",
     "codemod:imports": "tsx scripts/codemod-rewrite-imports.ts",
+    "release:notes": "tsx scripts/generate-release-notes.ts"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.2.6",

--- a/scripts/generate-release-notes.ts
+++ b/scripts/generate-release-notes.ts
@@ -1,0 +1,33 @@
+import { execSync } from 'node:child_process'
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+async function main() {
+  const log = execSync('git log -n 20 --pretty=format:%s', {
+    encoding: 'utf8',
+  })
+    .trim()
+    .split('\n')
+    .filter(Boolean)
+
+  const commits = log.map((c) => `- ${c}`).join('\n')
+
+  const templatePath = path.join(__dirname, 'release-notes.md.ejs')
+  const outputPath = path.resolve(__dirname, '../RELEASE_NOTES.md')
+
+  const template = await fs.readFile(templatePath, 'utf8')
+  const content = template.replace('<%= commits %>', commits)
+
+  await fs.writeFile(outputPath, content)
+  console.log(`Generated ${outputPath}`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})
+

--- a/scripts/release-notes.md.ejs
+++ b/scripts/release-notes.md.ejs
@@ -1,0 +1,4 @@
+# Release Notes
+
+<%= commits %>
+


### PR DESCRIPTION
## Summary
- add EJS template and script to generate release notes from git log
- wire npm script `release:notes`

## Testing
- `npm run lint` *(fails: Parsing error: JSX element 'StrictMode' has no corresponding closing tag)*
- `npm run typecheck`
- `npm run release:notes`


------
https://chatgpt.com/codex/tasks/task_e_689a65ad985883229236983090f0c840