### PR TITLE
Add architecture and module overview docs

### DIFF
--- a/docs/ADR-0001-arquitetura.md
+++ b/docs/ADR-0001-arquitetura.md
@@ -1,0 +1,13 @@
+# ADR 0001: Visão geral da arquitetura
+
+## Contexto
+O projeto segue uma organização em camadas para manter a coesão e facilitar a evolução.
+
+## Decisão
+Adotar separação entre:
+- **Apresentação**: componentes de interface construídos em React.
+- **Negócio**: serviços e regras que tratam as transações de finanças, investimentos, metas e milhas.
+- **Persistência**: acesso aos dados realizado via Supabase.
+
+## Consequências
+Essa abordagem permite isolamento entre responsabilidades e torna mais fácil testar e evoluir cada parte do sistema de forma independente.

--- a/docs/finance.md
+++ b/docs/finance.md
@@ -1,0 +1,3 @@
+# Finanças
+
+O módulo de Finanças centraliza o registro de entradas e saídas de dinheiro. Ele oferece visão geral do orçamento, categorização de transações e relatórios para planejamento financeiro.

--- a/docs/goals.md
+++ b/docs/goals.md
@@ -1,0 +1,3 @@
+# Metas
+
+O módulo de Metas ajuda a definir objetivos financeiros e monitorar o progresso. É possível estabelecer alvos de poupança, acompanhar etapas e ajustar planos conforme a evolução das finanças pessoais.

--- a/docs/investments.md
+++ b/docs/investments.md
@@ -1,0 +1,3 @@
+# Investimentos
+
+O módulo de Investimentos acompanha ativos como ações, fundos e renda fixa. Seu objetivo é oferecer um panorama das aplicações e do desempenho ao longo do tempo, permitindo decisões informadas sobre alocação de capital.

--- a/docs/miles.md
+++ b/docs/miles.md
@@ -1,0 +1,3 @@
+# Milhas
+
+O módulo de Milhas reúne informações sobre programas de fidelidade e pontos acumulados. Seu foco é acompanhar saldo, expiração e oportunidades de uso para maximizar benefícios em viagens.


### PR DESCRIPTION
## Summary
- add ADR for system architecture
- document finance, investments, goals, and miles modules

## Testing
- `npm test` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a65bd815c8322a3f71102f4141d01