### PR TITLE
feat(ui): polish Finanças Mensal filter bar for consistent visual style

### DIFF
--- a/src/components/CategoryPicker.tsx
+++ b/src/components/CategoryPicker.tsx
@@ -24,10 +24,14 @@ type Props = {
   value: string | null | undefined;
   onChange: (id: string | null) => void;
   placeholder?: string;
+  /** optional aria-label for the select trigger */
+  ariaLabel?: string;
   kind?: "expense" | "income" | "transfer" | "all";
   allowClear?: boolean;
   allowCreate?: boolean;
   onRequestCreate?: () => void;
+  /** when true, include an option to select all categories */
+  showAll?: boolean;
   className?: string;
 };
 
@@ -35,11 +39,13 @@ export default function CategoryPicker({
   value,
   onChange,
   placeholder = "Selecione a categoria",
+  ariaLabel,
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- API placeholder
   kind: _kind = "all",
   allowClear = true,
   allowCreate = false,
   onRequestCreate,
+  showAll = false,
   className = "",
 }: Props) {
   const { flat, byId, create, update, remove } = useCategories();
@@ -134,22 +140,21 @@ export default function CategoryPicker({
 
   return (
     <div className={`flex w-full items-center gap-2 ${className}`}>
-      <Select
-        value={value ?? undefined}
-        onValueChange={(v) => onChange(v || null)}
-      >
-        <SelectTrigger className="w-full">
+      <Select value={value ?? undefined} onValueChange={(v) => onChange(v || null)}>
+        <SelectTrigger
+          aria-label={ariaLabel ?? placeholder}
+          className="w-full h-10 rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10"
+        >
           <SelectValue placeholder={placeholder} />
         </SelectTrigger>
-        <SelectContent className="max-h-80">
+        <SelectContent className="max-h-80 rounded-xl">
+          {showAll && <SelectItem value="">Todas</SelectItem>}
           {options.map((opt) => (
             <SelectItem key={opt.id} value={opt.id}>
               <span className="inline-flex items-center gap-2">
                 <span
                   className="h-2.5 w-2.5 rounded-full"
-                  style={{
-                    backgroundColor: byId.get(opt.id)?.color || "#CBD5E1",
-                  }}
+                  style={{ backgroundColor: byId.get(opt.id)?.color || "#CBD5E1" }}
                 />
                 {opt.label}
               </span>

--- a/src/components/SourcePicker.tsx
+++ b/src/components/SourcePicker.tsx
@@ -17,6 +17,7 @@ export default function SourcePicker({
   value,
   onChange,
   placeholder = "Selecione a fonte",
+  ariaLabel,
   allowCreate = false,
   showCardHints = true,
   className = "",
@@ -24,6 +25,7 @@ export default function SourcePicker({
   value: SourceValue;
   onChange: (s: SourceValue) => void;
   placeholder?: string;
+  ariaLabel?: string;
   allowCreate?: boolean;
   showCardHints?: boolean;
   className?: string;
@@ -99,7 +101,10 @@ export default function SourcePicker({
           value={selectedId ?? ""}
           onValueChange={(v) => onChange({ kind: "account", id: v || null })}
         >
-          <SelectTrigger className="w-full h-10 rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10">
+          <SelectTrigger
+            aria-label={ariaLabel ?? placeholder}
+            className="w-full h-10 rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10"
+          >
             <SelectValue placeholder={placeholder} />
           </SelectTrigger>
           <SelectContent className="rounded-xl max-h-72">
@@ -123,13 +128,16 @@ export default function SourcePicker({
             value={selectedId ?? ""}
             onValueChange={(v) => onChange({ kind: "card", id: v || null })}
           >
-            <SelectTrigger className="w-full h-10 rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10">
-              <SelectValue placeholder={placeholder} />
-            </SelectTrigger>
-            <SelectContent className="rounded-xl max-h-72">
-              <SelectItem value="">Todas</SelectItem>
-              {cards.map((c) => (
-                <SelectItem key={c.id} value={c.id}>
+          <SelectTrigger
+            aria-label={ariaLabel ?? placeholder}
+            className="w-full h-10 rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10"
+          >
+            <SelectValue placeholder={placeholder} />
+          </SelectTrigger>
+          <SelectContent className="rounded-xl max-h-72">
+            <SelectItem value="">Todas</SelectItem>
+            {cards.map((c) => (
+              <SelectItem key={c.id} value={c.id}>
                   <span className="inline-flex items-center gap-2">
                     <span className="h-2.5 w-2.5 rounded-full bg-sky-500" />
                     <span className="font-medium">{c.name}</span>

--- a/src/pages/FinancasMensal.tsx
+++ b/src/pages/FinancasMensal.tsx
@@ -26,6 +26,7 @@ import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/comp
 
 import { useCategories } from '@/hooks/useCategories';
 import SourcePicker, { type SourceValue } from '@/components/SourcePicker';
+import CategoryPicker from '@/components/CategoryPicker';
 import { Skeleton } from '@/components/ui/Skeleton';
 import { EmptyState } from '@/components/ui/EmptyState';
 
@@ -137,13 +138,7 @@ export default function FinancasMensal() {
     useTransactions(year, month);
 
   // ===== categorias (mapear id -> nome) =====
-  const { flat: categorias, byId: categoriasById } = useCategories();
-
-  type CategoriaOption = { id: string; name: string };
-  const categoriasOptions: CategoriaOption[] = useMemo(() => {
-    const base = categorias.map((c) => ({ id: c.id, name: c.name }));
-    return [{ id: 'Todas', name: 'Todas' }, ...base];
-  }, [categorias]);
+  const { byId: categoriasById } = useCategories();
 
   // ===== converter para UI (type/value) =====
   const uiTransacoes: UITransaction[] = useMemo(() => {
@@ -330,7 +325,10 @@ export default function FinancasMensal() {
           <div>
             <span className="mb-1 block text-xs text-emerald-100/90">Mês</span>
             <Select value={mesAtual} onValueChange={setMesAtual}>
-              <SelectTrigger className="w-full h-10 rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10">
+              <SelectTrigger
+                aria-label="Mês"
+                className="w-full h-10 rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10"
+              >
                 <SelectValue placeholder="Selecione o mês" />
               </SelectTrigger>
               <SelectContent className="rounded-xl">
@@ -350,18 +348,15 @@ export default function FinancasMensal() {
           {/* Categoria */}
           <div>
             <span className="mb-1 block text-xs text-emerald-100/90">Categoria</span>
-            <Select value={categoriaId} onValueChange={(v) => setCategoriaId(v as string | 'Todas')}>
-              <SelectTrigger className="w-full h-10 rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10">
-                <SelectValue placeholder="Todas" />
-              </SelectTrigger>
-              <SelectContent className="rounded-xl max-h-72">
-                {categoriasOptions.map((cat) => (
-                  <SelectItem key={cat.id} value={cat.id}>
-                    {cat.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+            <CategoryPicker
+              value={categoriaId === 'Todas' ? null : categoriaId}
+              onChange={(v) => setCategoriaId(v ?? 'Todas')}
+              placeholder="Todas"
+              ariaLabel="Categoria"
+              showAll
+              allowClear={false}
+              className="w-full"
+            />
           </div>
 
           {/* Fonte */}
@@ -371,6 +366,7 @@ export default function FinancasMensal() {
               value={fonte}
               onChange={setFonte}
               placeholder="Todas"
+              ariaLabel="Fonte"
               className="w-full"
               showCardHints={false}
             />
@@ -385,6 +381,7 @@ export default function FinancasMensal() {
                 value={buscaInput}
                 onChange={(e) => setBuscaInput(e.target.value)}
                 placeholder="Descrição, loja, observações…"
+                aria-label="Buscar"
                 className="w-full h-10 pl-9 rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10"
               />
             </div>


### PR DESCRIPTION
## Summary
- modernize Finanças Mensal filters with responsive grid, polished chrome and accessibility labels
- streamline SourcePicker and CategoryPicker with unified value shapes and “Todas” options

## Testing
- `npm install` *(fails: Invalid package.json)*
- `npm run lint` *(fails: Invalid package.json)*
- `npm run typecheck` *(fails: Invalid package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a6f59c93c83229444abc6962fc90a