### PR TITLE
feat: add receipt OCR stub

### DIFF
--- a/src/components/ModalTransacao.tsx
+++ b/src/components/ModalTransacao.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -9,8 +11,8 @@ import SourcePicker, { type SourceValue } from '@/components/SourcePicker';
 import { useCategories } from '@/hooks/useCategories';
 import { useAccounts } from '@/hooks/useAccounts';
 import { useCreditCards } from '@/hooks/useCreditCards';
-import { toast } from 'sonner';
 import MoneyInput from '@/components/MoneyInput';
+import ReceiptUpload from '@/components/ReceiptUpload';
 
 // --- Types -----------------------------------------------------------------
 export type BaseData = {
@@ -291,15 +293,18 @@ export function ModalTransacao({ open, onClose, initialData, onSubmit }: Props) 
             </div>
           )}
 
-          {/* Anexo (nota/recibo) */}
+          {/* Anexo (nota/recibo) com OCR */}
           <div className="grid gap-1">
             <Label>Anexo (nota/recibo — PDF/Imagem)</Label>
-            <input
-              type="file"
-              accept="application/pdf,image/*"
-              onChange={(e) => handleChange('attachment_file', e.target.files?.[0] || null)}
+            <ReceiptUpload
+              onFileChange={(f) => handleChange('attachment_file', f)}
+              onParsed={(data) => {
+                if (data.description) handleChange('description', data.description);
+                if (typeof data.value === 'number') handleChange('value', data.value);
+                if (data.date) handleChange('date', data.date);
+              }}
             />
-            <span className="text-xs text-slate-500">(Opcional; upload/extração OCR entram no próximo passo.)</span>
+            <span className="text-xs text-slate-500">(Opcional; tamanho máx. 5MB.)</span>
           </div>
         </div>
 

--- a/src/components/ReceiptUpload.tsx
+++ b/src/components/ReceiptUpload.tsx
@@ -1,13 +1,22 @@
 import { useEffect, useState, type ChangeEvent } from "react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
 import { useReceiptOCR, type ReceiptData } from "@/hooks/useReceiptOCR";
 
 type Props = {
-  onExtract: (data: ReceiptData) => void;
+  /** Dispara quando o OCR extrai os dados com sucesso */
+  onParsed: (data: ReceiptData) => void;
+  /** Prop opcional para repassar o arquivo selecionado ao componente pai */
+  onFileChange?: (file: File | null) => void;
 };
 
-export default function ReceiptUpload({ onExtract }: Props) {
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
+export default function ReceiptUpload({ onParsed, onFileChange }: Props) {
   const [file, setFile] = useState<File | null>(null);
   const [previewUrl, setPreviewUrl] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
   const { parse } = useReceiptOCR();
 
   useEffect(() => {
@@ -16,22 +25,37 @@ export default function ReceiptUpload({ onExtract }: Props) {
     };
   }, [previewUrl]);
 
-  const onFileChange = (e: ChangeEvent<HTMLInputElement>) => {
+  const onFileInput = (e: ChangeEvent<HTMLInputElement>) => {
     const f = e.target.files?.[0] ?? null;
+    if (f && f.size > MAX_FILE_SIZE) {
+      toast.error("Arquivo muito grande (máx. 5MB)");
+      e.target.value = "";
+      return;
+    }
     if (previewUrl) URL.revokeObjectURL(previewUrl);
     setFile(f);
     setPreviewUrl(f ? URL.createObjectURL(f) : null);
+    onFileChange?.(f);
   };
 
   const extract = async () => {
     if (!file) return;
-    const data = await parse(file);
-    onExtract(data);
+    setLoading(true);
+    try {
+      const data = await parse(file);
+      onParsed(data);
+      toast.success("Dados preenchidos!");
+    } catch (e: any) {
+      console.error(e);
+      toast.error(e?.message || "Falha ao extrair dados");
+    } finally {
+      setLoading(false);
+    }
   };
 
   return (
     <div className="flex flex-col gap-4">
-      <input type="file" accept="image/*,application/pdf" onChange={onFileChange} />
+      <input type="file" accept="image/*,application/pdf" onChange={onFileInput} />
       {previewUrl && (
         <div className="max-w-xs">
           {file?.type === "application/pdf" ? (
@@ -41,14 +65,9 @@ export default function ReceiptUpload({ onExtract }: Props) {
           )}
         </div>
       )}
-      <button
-        type="button"
-        onClick={extract}
-        disabled={!file}
-        className="rounded bg-emerald-600 px-4 py-2 text-white disabled:opacity-50"
-      >
-        Extrair dados
-      </button>
+      <Button type="button" onClick={extract} disabled={!file || loading}>
+        {loading ? "Processando..." : "Preencher com OCR"}
+      </Button>
     </div>
   );
 }

--- a/src/hooks/useReceiptOCR.ts
+++ b/src/hooks/useReceiptOCR.ts
@@ -1,20 +1,57 @@
 import { useCallback } from "react";
 
 export type ReceiptData = {
+  /** Texto descritivo identificado na nota */
   description: string;
-  value: number;
-  date: string;
+  /** Valor numérico em reais, se identificado */
+  value?: number;
+  /** Data no formato YYYY-MM-DD, se identificada */
+  date?: string;
 };
 
+// Heurísticas extremamente simples para extrair informações de um arquivo de nota/recibo.
+// Não utiliza nenhum serviço externo de OCR — apenas tenta interpretar o conteúdo bruto do
+// arquivo (PDF ou texto) quando possível. Para imagens, normalmente retornará apenas o nome.
 export function useReceiptOCR() {
   const parse = useCallback(async (file: File): Promise<ReceiptData> => {
-    void file;
-    // Stub: return simulated data
-    return {
-      description: "Compra Mercado X",
-      value: 123.45,
-      date: "2025-08-11",
-    };
+    // Nome do arquivo, sem extensão, usado como fallback de descrição
+    const description = file.name.replace(/\.[^/.]+$/, "");
+    let text = "";
+
+    try {
+      // `File.text()` funciona para PDFs com texto selecionável e arquivos texto.
+      // Para imagens ou PDFs somente-imagem, provavelmente retornará dados ilegíveis,
+      // o que é aceitável para este stub local.
+      if (file.type.startsWith("text/") || file.type === "application/pdf") {
+        text = await file.text();
+      }
+    } catch {
+      // ignoramos erros — seguiremos apenas com o nome do arquivo
+    }
+
+    const result: ReceiptData = { description };
+
+    if (text) {
+      // Valor: procura padrões como "R$ 123,45" ou "123.45"
+      const valueMatch = text.match(/(?:R\$\s*)?([0-9]{1,3}(?:[.\s][0-9]{3})*(?:[,.][0-9]{2}))/);
+      if (valueMatch) {
+        const normalized = valueMatch[1].replace(/\./g, "").replace(",", ".");
+        const n = parseFloat(normalized);
+        if (!Number.isNaN(n)) result.value = n;
+      }
+
+      // Data: aceita "YYYY-MM-DD" ou "DD/MM/YYYY"
+      const dateIso = text.match(/(\d{4}-\d{2}-\d{2})/);
+      const dateBr = text.match(/(\d{2})[/-](\d{2})[/-](\d{4})/);
+      if (dateIso) {
+        result.date = dateIso[1];
+      } else if (dateBr) {
+        const [, d, m, y] = dateBr;
+        result.date = `${y}-${m}-${d}`;
+      }
+    }
+
+    return result;
   }, []);
 
   return { parse };


### PR DESCRIPTION
## Summary
- add local OCR hook that extracts description, value and date from receipts using basic heuristics
- create `ReceiptUpload` component with preview, size limit and toast feedback
- integrate receipt upload in transaction modal to auto-fill fields

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: import-order errors across repo)*
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_689cb4b1089c8322b37d460ea4cfdc93