### PR TITLE
feat: add annual finance summary page

### DIFF
--- a/src/components/charts/CategoryDonut.tsx
+++ b/src/components/charts/CategoryDonut.tsx
@@ -1,25 +1,36 @@
 // src/components/charts/CategoryDonut.tsx
-import { useMemo } from 'react';
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
-import { mapCategoryColor } from '@/lib/palette';
-import type { UITransaction } from '@/components/TransactionsTable';
+import { useMemo } from "react";
+import {
+  PieChart,
+  Pie,
+  Cell,
+  ResponsiveContainer,
+  Tooltip,
+  Legend,
+} from "recharts";
+
+import { mapCategoryColor } from "@/lib/palette";
+import type { UITransaction } from "@/components/TransactionsTable";
 
 type Props = {
   transacoes?: UITransaction[];
   mes?: string;
-  categoriesData?: Array<{ category: string; value: number }>;
+  categoriesData?: Array<{ name: string; total: number }>;
 };
 
-export default function CategoryDonut({ transacoes = [], categoriesData }: Props) {
+export default function CategoryDonut({
+  transacoes = [],
+  categoriesData,
+}: Props) {
   // soma por categoria (apenas despesas)
   const data = useMemo(() => {
     if (categoriesData) {
-      return categoriesData.map((c) => ({ name: c.category, value: c.value }));
+      return categoriesData.map((c) => ({ name: c.name, value: c.total }));
     }
     const byCat = transacoes
-      .filter((t) => t.type === 'expense')
+      .filter((t) => t.type === "expense")
       .reduce<Record<string, number>>((acc, t) => {
-        const key = t.category || 'Sem categoria';
+        const key = t.category || "Sem categoria";
         acc[key] = (acc[key] ?? 0) + t.value;
         return acc;
       }, {});
@@ -50,16 +61,16 @@ export default function CategoryDonut({ transacoes = [], categoriesData }: Props
               paddingAngle={2}
               label={({ percent = 0 }) => `${(percent * 100).toFixed(0)}%`}
               labelLine={false}
-              >
-                {data.map((entry) => (
-                  <Cell key={entry.name} fill={mapCategoryColor(entry.name)} />
-                ))}
-              </Pie>
+            >
+              {data.map((entry) => (
+                <Cell key={entry.name} fill={mapCategoryColor(entry.name)} />
+              ))}
+            </Pie>
             <Tooltip
               formatter={(v: number) =>
-                (Number(v) || 0).toLocaleString('pt-BR', {
-                  style: 'currency',
-                  currency: 'BRL',
+                (Number(v) || 0).toLocaleString("pt-BR", {
+                  style: "currency",
+                  currency: "BRL",
                 })
               }
               labelFormatter={(name: string) => name}

--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -1,17 +1,18 @@
 import { useEffect, useMemo, useState, useCallback } from "react";
+
 import { supabase } from "@/lib/supabaseClient";
 
 // ===== Tipos base (compatíveis com tabela atual) ============================
 export type Transaction = {
-  id: number;                 // bigint
-  date: string;               // YYYY-MM-DD (UTC)
+  id: number; // bigint
+  date: string; // YYYY-MM-DD (UTC)
   description: string;
-  amount: number;             // < 0 despesa, > 0 receita
+  amount: number; // < 0 despesa, > 0 receita
   category_id?: string | null;
   account_id?: string | null;
   card_id?: string | null;
-  installment_no?: number | null;      // 1..N
-  installment_total?: number | null;   // N
+  installment_no?: number | null; // 1..N
+  installment_total?: number | null; // N
   parent_installment_id?: number | null; // (opcional se usarmos mais tarde)
 };
 
@@ -54,14 +55,18 @@ function monthBoundsISO(year?: unknown, month?: unknown) {
 function addMonthsISO(iso: string, months: number) {
   // iso: YYYY-MM-DD (UTC)
   const [Y, M, D] = iso.split("-").map((n) => Number(n));
-  const d = new Date(Date.UTC(Y, (M - 1) + months, D));
+  const d = new Date(Date.UTC(Y, M - 1 + months, D));
   return d.toISOString().slice(0, 10);
 }
 
 function daysInMonth(y: number, m1to12: number) {
   return new Date(Date.UTC(y, m1to12, 0)).getUTCDate();
 }
-function mapDateToYearMonth(iso: string, targetY: number, targetM1to12: number) {
+function mapDateToYearMonth(
+  iso: string,
+  targetY: number,
+  targetM1to12: number,
+) {
   // Mantém o dia, mas recorta se o mês alvo tiver menos dias
   const [, , D] = iso.split("-").map((n) => Number(n));
   const maxD = daysInMonth(targetY, targetM1to12);
@@ -74,45 +79,70 @@ function stripInstallmentSuffix(desc: string) {
 }
 function toCSV(rows: Transaction[]) {
   const head = [
-    "id","date","description","amount","category_id","account_id","card_id","installment_no","installment_total","parent_installment_id",
+    "id",
+    "date",
+    "description",
+    "amount",
+    "category_id",
+    "account_id",
+    "card_id",
+    "installment_no",
+    "installment_total",
+    "parent_installment_id",
   ];
   const esc = (v: unknown) => {
     if (v === null || v === undefined) return "";
     const s = String(v);
     return /[",\n]/.test(s) ? '"' + s.replace(/"/g, '""') + '"' : s;
   };
-  const body = rows.map(r => head.map(k => esc((r as Record<string, unknown>)[k])).join(","));
+  const body = rows.map((r) =>
+    head.map((k) => esc((r as Record<string, unknown>)[k])).join(","),
+  );
   return head.join(",") + "\n" + body.join("\n");
 }
 
 export type YearSummary = {
-  year: number;
   months: Array<{
     month: number;
     income: number;
     expense: number;
     balance: number;
-    byCategory: Record<string, number>;
   }>;
-  totalIncome: number;
-  totalExpense: number;
-  totalBalance: number;
+  byCategory: Array<{
+    categoryId: string | null;
+    name: string;
+    total: number;
+  }>;
+  totals: {
+    income: number;
+    expense: number;
+    balance: number;
+  };
+  /** Mês (1..12) com maior despesa. 0 se não houver despesas. */
+  worstMonth: number;
 };
 
 /**
- * Retorna agregações anuais de transações agrupadas por mês e categoria.
+ * Busca transações do ano e gera agregações por mês e por categoria.
  * - `income` e `expense` são valores positivos.
  * - `balance` = income - expense.
- * - `byCategory` contém apenas despesas agrupadas por categoria.
+ * - `byCategory` agrega somente despesas.
  */
 export async function getYearSummary(year: number): Promise<YearSummary> {
   const y = Number(year);
   const start = isoDateUTC(y, 0, 1);
   const end = isoDateUTC(y, 11, 31);
 
+  type Row = {
+    date: string;
+    amount: number;
+    category_id: string | null;
+    categories?: { name: string | null } | null;
+  };
+
   const { data, error } = await supabase
     .from("transactions")
-    .select("date, amount, category_id")
+    .select("date, amount, category_id, categories(name)")
     .gte("date", start)
     .lte("date", end);
   if (error) throw error;
@@ -122,39 +152,59 @@ export async function getYearSummary(year: number): Promise<YearSummary> {
     income: 0,
     expense: 0,
     balance: 0,
-    byCategory: {} as Record<string, number>,
   }));
 
-  let totalIncome = 0;
-  let totalExpense = 0;
+  const byCat = new Map<
+    string,
+    { categoryId: string | null; name: string; total: number }
+  >();
 
-  (data || []).forEach((t) => {
-    const mIdx = Number((t.date as string).slice(5, 7)) - 1;
+  (data as Row[] | null | undefined)?.forEach((t) => {
+    const mIdx = Number(t.date.slice(5, 7)) - 1;
     if (mIdx < 0 || mIdx > 11) return;
     const amount = Number(t.amount) || 0;
     if (amount >= 0) {
       months[mIdx].income += amount;
-      totalIncome += amount;
     } else {
       const v = Math.abs(amount);
       months[mIdx].expense += v;
-      totalExpense += v;
-      const cat = ((t.category_id as string | null) ?? 'null') as string;
-      const catMap = months[mIdx].byCategory;
-      catMap[cat] = (catMap[cat] ?? 0) + v;
+      const catId = t.category_id || null;
+      const key = catId || "null";
+      const name = t.categories?.name ?? "Sem categoria";
+      const entry = byCat.get(key) || { categoryId: catId, name, total: 0 };
+      entry.total += v;
+      byCat.set(key, entry);
     }
   });
 
+  let worstMonth = 0;
+  let worstValue = 0;
   months.forEach((m) => {
     m.balance = (Number(m.income) || 0) - (Number(m.expense) || 0);
+    if (m.expense > worstValue) {
+      worstValue = m.expense;
+      worstMonth = m.month;
+    }
   });
 
+  const totals = months.reduce(
+    (acc, m) => {
+      acc.income += m.income;
+      acc.expense += m.expense;
+      return acc;
+    },
+    { income: 0, expense: 0 },
+  );
+
   return {
-    year: y,
     months,
-    totalIncome,
-    totalExpense,
-    totalBalance: totalIncome - totalExpense,
+    byCategory: Array.from(byCat.values()),
+    totals: {
+      income: totals.income,
+      expense: totals.expense,
+      balance: totals.income - totals.expense,
+    },
+    worstMonth,
   };
 }
 
@@ -164,7 +214,10 @@ export function useTransactions(year?: any, month?: any) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const { y, m, start, end } = useMemo(() => monthBoundsISO(year, month), [year, month]);
+  const { y, m, start, end } = useMemo(
+    () => monthBoundsISO(year, month),
+    [year, month],
+  );
 
   // ----- Load (por período) -------------------------------------------------
   const list = useCallback(async () => {
@@ -189,37 +242,57 @@ export function useTransactions(year?: any, month?: any) {
     }
   }, [start, end]);
 
-  useEffect(() => { if (start && end) void list(); }, [list, start, end]);
+  useEffect(() => {
+    if (start && end) void list();
+  }, [list, start, end]);
 
   // ----- CRUD de baixo nível (compat) --------------------------------------
-  const create = useCallback(async (t: Omit<Transaction, "id">) => {
-    const { error } = await supabase
-      .from("transactions")
-      .insert(t as unknown as Transaction);
-    if (error) throw error;
-    await list();
-  }, [list]);
+  const create = useCallback(
+    async (t: Omit<Transaction, "id">) => {
+      const { error } = await supabase
+        .from("transactions")
+        .insert(t as unknown as Transaction);
+      if (error) throw error;
+      await list();
+    },
+    [list],
+  );
 
-  const bulkCreate = useCallback(async (rows: Omit<Transaction, "id">[]) => {
-    if (!rows?.length) return;
-    const { error } = await supabase
-      .from("transactions")
-      .insert(rows as unknown as Transaction[]);
-    if (error) throw error;
-    await list();
-  }, [list]);
+  const bulkCreate = useCallback(
+    async (rows: Omit<Transaction, "id">[]) => {
+      if (!rows?.length) return;
+      const { error } = await supabase
+        .from("transactions")
+        .insert(rows as unknown as Transaction[]);
+      if (error) throw error;
+      await list();
+    },
+    [list],
+  );
 
-  const update = useCallback(async (id: number, patch: Partial<Transaction>) => {
-    const { error } = await supabase.from("transactions").update(patch).eq("id", id);
-    if (error) throw error;
-    await list();
-  }, [list]);
+  const update = useCallback(
+    async (id: number, patch: Partial<Transaction>) => {
+      const { error } = await supabase
+        .from("transactions")
+        .update(patch)
+        .eq("id", id);
+      if (error) throw error;
+      await list();
+    },
+    [list],
+  );
 
-  const remove = useCallback(async (id: number) => {
-    const { error } = await supabase.from("transactions").delete().eq("id", id);
-    if (error) throw error;
-    await list();
-  }, [list]);
+  const remove = useCallback(
+    async (id: number) => {
+      const { error } = await supabase
+        .from("transactions")
+        .delete()
+        .eq("id", id);
+      if (error) throw error;
+      await list();
+    },
+    [list],
+  );
 
   // ----- Nivel alto: criação com regras de negócio -------------------------
   /**
@@ -228,61 +301,69 @@ export function useTransactions(year?: any, month?: any) {
    * - Se cartão + parcelas>1: gera N lançamentos mensais com installment_no/total
    * - Mapeia source_kind/source_id para account_id/card_id
    */
-  const addSmart = useCallback(async (dto: TransactionInput) => {
-    const baseValue = Math.abs(Number(dto.value || 0));
-    if (!baseValue) throw new Error("Valor inválido");
+  const addSmart = useCallback(
+    async (dto: TransactionInput) => {
+      const baseValue = Math.abs(Number(dto.value || 0));
+      if (!baseValue) throw new Error("Valor inválido");
 
-    const amount = dto.type === "expense" ? -baseValue : baseValue;
+      const amount = dto.type === "expense" ? -baseValue : baseValue;
 
-    const isCard = dto.source_kind === "card" && dto.source_id;
-    const installments = isCard ? Math.max(1, Number(dto.installments || 1)) : 1;
+      const isCard = dto.source_kind === "card" && dto.source_id;
+      const installments = isCard
+        ? Math.max(1, Number(dto.installments || 1))
+        : 1;
 
-    const common = {
-      description: dto.description?.trim() || "",
-      category_id: dto.category_id ?? null,
-      account_id: !isCard ? (dto.source_id ?? null) : null,
-      card_id: isCard ? (dto.source_id ?? null) : null,
-    } as Omit<Transaction, "id" | "date" | "amount">;
+      const common = {
+        description: dto.description?.trim() || "",
+        category_id: dto.category_id ?? null,
+        account_id: !isCard ? (dto.source_id ?? null) : null,
+        card_id: isCard ? (dto.source_id ?? null) : null,
+      } as Omit<Transaction, "id" | "date" | "amount">;
 
-    if (installments === 1) {
-      const row: Omit<Transaction, "id"> = {
-        date: dto.date,
-        description: common.description,
-        amount,
-        category_id: common.category_id,
-        account_id: common.account_id,
-        card_id: common.card_id,
-        installment_no: null,
-        installment_total: null,
-        parent_installment_id: null,
-      };
-      await create(row);
-      return;
-    }
+      if (installments === 1) {
+        const row: Omit<Transaction, "id"> = {
+          date: dto.date,
+          description: common.description,
+          amount,
+          category_id: common.category_id,
+          account_id: common.account_id,
+          card_id: common.card_id,
+          installment_no: null,
+          installment_total: null,
+          parent_installment_id: null,
+        };
+        await create(row);
+        return;
+      }
 
-    // Parcelado: gera N linhas mês a mês
-    const rows: Omit<Transaction, "id">[] = [];
-    for (let i = 0; i < installments; i++) {
-      const d = i === 0 ? dto.date : addMonthsISO(dto.date, i);
-      rows.push({
-        date: d,
-        description: `${common.description} (${i + 1}/${installments})`,
-        amount,
-        category_id: common.category_id,
-        account_id: common.account_id,
-        card_id: common.card_id,
-        installment_no: i + 1,
-        installment_total: installments,
-        parent_installment_id: null, // poderemos preencher depois se adotarmos grupo
-      });
-    }
-    await bulkCreate(rows);
-  }, [create, bulkCreate]);
+      // Parcelado: gera N linhas mês a mês
+      const rows: Omit<Transaction, "id">[] = [];
+      for (let i = 0; i < installments; i++) {
+        const d = i === 0 ? dto.date : addMonthsISO(dto.date, i);
+        rows.push({
+          date: d,
+          description: `${common.description} (${i + 1}/${installments})`,
+          amount,
+          category_id: common.category_id,
+          account_id: common.account_id,
+          card_id: common.card_id,
+          installment_no: i + 1,
+          installment_total: installments,
+          parent_installment_id: null, // poderemos preencher depois se adotarmos grupo
+        });
+      }
+      await bulkCreate(rows);
+    },
+    [create, bulkCreate],
+  );
 
   // ----- Filtros locais (UI) -----------------------------------------------
 
   /** Obtém uma transação pelo id a partir do cache atual (ou undefined). */
-  const getById = useCallback((id: number) => data.find(d => d.id === id), [data]);
+  const getById = useCallback(
+    (id: number) => data.find((d) => d.id === id),
+    [data],
+  );
 
   /**
    * Duplica várias transações para um mês/ano alvo.
@@ -290,62 +371,68 @@ export function useTransactions(year?: any, month?: any) {
    * - Se a origem for parcelada (installment_total>1), recria a série completa a partir do novo mês.
    * - Remove sufixos (x/N) da descrição ao gerar novas parcelas.
    */
-  const duplicateMany = useCallback(async (
-    ids: number[],
-    targetYear: number,
-    targetMonth1to12: number,
-  ) => {
-    if (!ids?.length) return;
-    const pick = data.filter(d => ids.includes(d.id));
-    if (!pick.length) return;
+  const duplicateMany = useCallback(
+    async (ids: number[], targetYear: number, targetMonth1to12: number) => {
+      if (!ids?.length) return;
+      const pick = data.filter((d) => ids.includes(d.id));
+      if (!pick.length) return;
 
-    const rows: Omit<Transaction, "id">[] = [];
-    for (const src of pick) {
-      const baseDesc = stripInstallmentSuffix(src.description);
-      const baseDate = mapDateToYearMonth(src.date, targetYear, targetMonth1to12);
+      const rows: Omit<Transaction, "id">[] = [];
+      for (const src of pick) {
+        const baseDesc = stripInstallmentSuffix(src.description);
+        const baseDate = mapDateToYearMonth(
+          src.date,
+          targetYear,
+          targetMonth1to12,
+        );
 
-      const isParcelado = (src.installment_total || 0) > 1 && src.card_id;
-      if (!isParcelado) {
-        rows.push({
-          date: baseDate,
-          description: baseDesc,
-          amount: src.amount,
-          category_id: src.category_id ?? null,
-          account_id: src.account_id ?? null,
-          card_id: src.card_id ?? null,
-          installment_no: null,
-          installment_total: null,
-          parent_installment_id: null,
-        });
-        continue;
+        const isParcelado = (src.installment_total || 0) > 1 && src.card_id;
+        if (!isParcelado) {
+          rows.push({
+            date: baseDate,
+            description: baseDesc,
+            amount: src.amount,
+            category_id: src.category_id ?? null,
+            account_id: src.account_id ?? null,
+            card_id: src.card_id ?? null,
+            installment_no: null,
+            installment_total: null,
+            parent_installment_id: null,
+          });
+          continue;
+        }
+        // Recria a série parcelada a partir do mês alvo
+        const total = Number(src.installment_total);
+        for (let i = 0; i < total; i++) {
+          const d = i === 0 ? baseDate : addMonthsISO(baseDate, i);
+          rows.push({
+            date: d,
+            description: `${baseDesc} (${i + 1}/${total})`,
+            amount: src.amount,
+            category_id: src.category_id ?? null,
+            account_id: null, // parcelas em cartão
+            card_id: src.card_id ?? null,
+            installment_no: i + 1,
+            installment_total: total,
+            parent_installment_id: null,
+          });
+        }
       }
-      // Recria a série parcelada a partir do mês alvo
-      const total = Number(src.installment_total);
-      for (let i = 0; i < total; i++) {
-        const d = i === 0 ? baseDate : addMonthsISO(baseDate, i);
-        rows.push({
-          date: d,
-          description: `${baseDesc} (${i + 1}/${total})`,
-          amount: src.amount,
-          category_id: src.category_id ?? null,
-          account_id: null,              // parcelas em cartão
-          card_id: src.card_id ?? null,
-          installment_no: i + 1,
-          installment_total: total,
-          parent_installment_id: null,
-        });
-      }
-    }
-    await bulkCreate(rows);
-  }, [data, bulkCreate]);
+      await bulkCreate(rows);
+    },
+    [data, bulkCreate],
+  );
 
   /** Exporta linhas selecionadas para CSV (string). */
-  const exportSelectedCSV = useCallback((ids: number[]) => {
-    const rows = !ids?.length ? data : data.filter(d => ids.includes(d.id));
-    return toCSV(rows);
-  }, [data]);
+  const exportSelectedCSV = useCallback(
+    (ids: number[]) => {
+      const rows = !ids?.length ? data : data.filter((d) => ids.includes(d.id));
+      return toCSV(rows);
+    },
+    [data],
+  );
   type LocalFilter = {
-    q?: string;                    // busca no description
+    q?: string; // busca no description
     categoryId?: string | null;
     source?: { kind: "account" | "card"; id: string | null } | null;
     type?: "income" | "expense" | "all";
@@ -359,19 +446,27 @@ export function useTransactions(year?: any, month?: any) {
     }
     if (f.categoryId) out = out.filter((t) => t.category_id === f.categoryId);
     if (f.source) {
-      if (f.source.kind === "account") out = out.filter((t) => t.account_id === f.source!.id);
-      if (f.source.kind === "card") out = out.filter((t) => t.card_id === f.source!.id);
+      if (f.source.kind === "account")
+        out = out.filter((t) => t.account_id === f.source!.id);
+      if (f.source.kind === "card")
+        out = out.filter((t) => t.card_id === f.source!.id);
     }
     if (f.type && f.type !== "all") {
-      out = out.filter((t) => (f.type === "income" ? t.amount > 0 : t.amount < 0));
+      out = out.filter((t) =>
+        f.type === "income" ? t.amount > 0 : t.amount < 0,
+      );
     }
     return out;
   }, []);
 
   // ----- KPIs --------------------------------------------------------------
   const kpis = useMemo(() => {
-    const entradas = data.filter((d) => d.amount > 0).reduce((s, d) => s + d.amount, 0);
-    const saidas = data.filter((d) => d.amount < 0).reduce((s, d) => s + d.amount, 0);
+    const entradas = data
+      .filter((d) => d.amount > 0)
+      .reduce((s, d) => s + d.amount, 0);
+    const saidas = data
+      .filter((d) => d.amount < 0)
+      .reduce((s, d) => s + d.amount, 0);
     return {
       entradas,
       saidas: Math.abs(saidas),

--- a/src/pages/FinancasAnual.tsx
+++ b/src/pages/FinancasAnual.tsx
@@ -1,21 +1,42 @@
-import { useEffect, useMemo, useState } from 'react';
-import dayjs from 'dayjs';
-import 'dayjs/locale/pt-br';
+import { useEffect, useMemo, useState } from "react";
+import dayjs from "dayjs";
+import "dayjs/locale/pt-br";
+import { Coins, TrendingUp, TrendingDown, CalendarRange } from "lucide-react";
+import {
+  ResponsiveContainer,
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from "recharts";
+import { Link } from "react-router-dom";
 
-import PageHeader from '@/components/PageHeader';
-import { MotionCard } from '@/components/ui/MotionCard';
-import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
-import { Coins, TrendingUp, TrendingDown, CalendarRange } from 'lucide-react';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import CategoryDonut from '@/components/charts/CategoryDonut';
-import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
-import { Button } from '@/components/ui/button';
-import { Link } from 'react-router-dom';
-import { useCategories } from '@/hooks/useCategories';
-import { getYearSummary, type YearSummary } from '@/hooks/useTransactions';
-import { ResponsiveContainer, AreaChart, Area, XAxis, YAxis, Tooltip } from 'recharts';
+import PageHeader from "@/components/PageHeader";
+import { MotionCard } from "@/components/ui/MotionCard";
+import { AnimatedNumber } from "@/components/ui/AnimatedNumber";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import CategoryDonut from "@/components/charts/CategoryDonut";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+import { Button } from "@/components/ui/button";
+import { getYearSummary, type YearSummary } from "@/hooks/useTransactions";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { EmptyState } from "@/components/ui/EmptyState";
 
-dayjs.locale('pt-br');
+dayjs.locale("pt-br");
 
 export default function FinancasAnual() {
   const [year, setYear] = useState(() => dayjs().year());
@@ -25,9 +46,7 @@ export default function FinancasAnual() {
 
   const yearOptions = useMemo(() => {
     const current = dayjs().year();
-    const arr: number[] = [];
-    for (let i = 0; i < 5; i++) arr.push(current - i);
-    return arr;
+    return Array.from({ length: 5 }, (_, i) => current - i);
   }, []);
 
   useEffect(() => {
@@ -36,42 +55,34 @@ export default function FinancasAnual() {
     getYearSummary(year)
       .then(setSummary)
       .catch((e: unknown) =>
-        setError(e instanceof Error ? e.message : 'Erro ao carregar')
+        setError(e instanceof Error ? e.message : "Erro ao carregar"),
       )
       .finally(() => setLoading(false));
   }, [year]);
 
-  const { byId: categoriasById } = useCategories();
-
-  const kpis = useMemo(() => {
-    if (!summary)
-      return { income: 0, expense: 0, balance: 0 };
-    return {
-      income: Number(summary.totalIncome) || 0,
-      expense: Number(summary.totalExpense) || 0,
-      balance: Number(summary.totalBalance) || 0,
-    };
-  }, [summary]);
-
-  const worstMonth = useMemo(() => {
-    if (!summary) return null;
-    const nonZero = summary.months.filter((m) => (Number(m.expense) || 0) > 0);
-    if (!nonZero.length) return null;
-    return nonZero.reduce((max, m) => (m.expense > max.expense ? m : max));
-  }, [summary]);
+  const kpis = summary?.totals ?? { income: 0, expense: 0, balance: 0 };
 
   const worstLabel = useMemo(() => {
-    if (!worstMonth) return '';
-    const mes = dayjs(`${year}-${String(worstMonth.month).padStart(2, '0')}-01`).format('MMMM');
+    if (!summary || !summary.worstMonth) return "";
+    const mes = dayjs(
+      `${year}-${String(summary.worstMonth).padStart(2, "0")}-01`,
+    ).format("MMMM");
     return mes.charAt(0).toUpperCase() + mes.slice(1);
-  }, [worstMonth, year]);
+  }, [summary, year]);
+
+  const worstValue = useMemo(() => {
+    if (!summary || !summary.worstMonth) return 0;
+    return (
+      summary.months.find((m) => m.month === summary.worstMonth)?.expense || 0
+    );
+  }, [summary]);
 
   const curveData = useMemo(() => {
     if (!summary) return [] as { mes: string; saldo: number }[];
     return summary.months.map((m) => {
       const label = dayjs(
-        `${year}-${String(m.month).padStart(2, '0')}-01`
-      ).format('MMM');
+        `${year}-${String(m.month).padStart(2, "0")}-01`,
+      ).format("MMM");
       return {
         mes: label.charAt(0).toUpperCase() + label.slice(1),
         saldo: m.balance,
@@ -79,37 +90,26 @@ export default function FinancasAnual() {
     });
   }, [summary, year]);
 
-  const categoriesData = useMemo(() => {
-    if (!summary) return [] as { category: string; value: number }[];
-    const agg: Record<string, number> = {};
-    summary.months.forEach((m) => {
-      Object.entries(m.byCategory).forEach(([cat, val]) => {
-        agg[cat] = (agg[cat] ?? 0) + (Number(val) || 0);
-      });
-    });
-    return Object.entries(agg).map(([catId, value]) => ({
-      category:
-        catId === 'null'
-          ? 'Sem categoria'
-          : categoriasById.get(catId)?.name ?? 'Sem categoria',
-      value,
-    }));
-  }, [summary, categoriasById]);
-
-  const monthsTable = useMemo(() => {
-    if (!summary) return [] as YearSummary['months'];
-    return summary.months;
-  }, [summary]);
+  const monthsTable = summary?.months ?? [];
 
   return (
     <div className="space-y-6 pb-24">
       <PageHeader
         title="Finanças — Anual"
-        actions={(
+        breadcrumbs={[
+          { label: "Finanças", href: "/financas/mensal" },
+          { label: "Anual" },
+        ]}
+        actions={
           <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 items-end">
             <div>
-              <span className="mb-1 block text-xs text-emerald-100/90">Ano</span>
-              <Select value={String(year)} onValueChange={(v) => setYear(Number(v))}>
+              <span className="mb-1 block text-xs text-emerald-100/90">
+                Ano
+              </span>
+              <Select
+                value={String(year)}
+                onValueChange={(v) => setYear(Number(v))}
+              >
                 <SelectTrigger className="w-full rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10">
                   <SelectValue placeholder="Ano" />
                 </SelectTrigger>
@@ -128,134 +128,192 @@ export default function FinancasAnual() {
               </Button>
             </div>
           </div>
-        )}
+        }
       />
 
       {/* KPIs */}
-      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
-        <MotionCard>
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-full bg-blue-600 text-white">
-              <TrendingUp size={18} />
+      {loading ? (
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          {Array.from({ length: 4 }).map((_, i) => (
+            <Skeleton key={i} className="h-24 w-full" />
+          ))}
+        </div>
+      ) : (
+        <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <MotionCard>
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-full bg-blue-600 text-white">
+                <TrendingUp size={18} />
+              </div>
+              <div className="flex flex-col">
+                <span className="text-sm text-slate-500 dark:text-slate-300">
+                  Entradas
+                </span>
+                <AnimatedNumber value={kpis.income} />
+              </div>
             </div>
-            <div className="flex flex-col">
-              <span className="text-sm text-slate-500 dark:text-slate-300">Entradas</span>
-              <AnimatedNumber value={kpis.income} />
-            </div>
-          </div>
-        </MotionCard>
+          </MotionCard>
 
-        <MotionCard>
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-full bg-rose-500 text-white">
-              <TrendingDown size={18} />
+          <MotionCard>
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-full bg-rose-500 text-white">
+                <TrendingDown size={18} />
+              </div>
+              <div className="flex flex-col">
+                <span className="text-sm text-slate-500 dark:text-slate-300">
+                  Saídas
+                </span>
+                <AnimatedNumber value={kpis.expense} />
+              </div>
             </div>
-            <div className="flex flex-col">
-              <span className="text-sm text-slate-500 dark:text-slate-300">Saídas</span>
-              <AnimatedNumber value={kpis.expense} />
-            </div>
-          </div>
-        </MotionCard>
+          </MotionCard>
 
-        <MotionCard>
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-full bg-emerald-600 text-white">
-              <Coins size={18} />
+          <MotionCard>
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-full bg-emerald-600 text-white">
+                <Coins size={18} />
+              </div>
+              <div className="flex flex-col">
+                <span className="text-sm text-slate-500 dark:text-slate-300">
+                  Saldo
+                </span>
+                <AnimatedNumber value={kpis.balance} />
+              </div>
             </div>
-            <div className="flex flex-col">
-              <span className="text-sm text-slate-500 dark:text-slate-300">Saldo</span>
-              <AnimatedNumber value={kpis.balance} />
-            </div>
-          </div>
-        </MotionCard>
+          </MotionCard>
 
-        <MotionCard>
-          <div className="flex items-center gap-3">
-            <div className="p-2 rounded-full bg-amber-500 text-white">
-              <CalendarRange size={18} />
+          <MotionCard>
+            <div className="flex items-center gap-3">
+              <div className="p-2 rounded-full bg-amber-500 text-white">
+                <CalendarRange size={18} />
+              </div>
+              <div className="flex flex-col">
+                <span className="text-sm text-slate-500 dark:text-slate-300">
+                  Mês com maior despesa
+                </span>
+                <AnimatedNumber value={worstValue} />
+                <span className="text-xs text-slate-500 dark:text-slate-300">
+                  {worstLabel || "—"}
+                </span>
+              </div>
             </div>
-            <div className="flex flex-col">
-              <span className="text-sm text-slate-500 dark:text-slate-300">Mês com maior despesa</span>
-              <AnimatedNumber value={worstMonth?.expense || 0} />
-              <span className="text-xs text-slate-500 dark:text-slate-300">{worstLabel || '—'}</span>
-            </div>
-          </div>
-        </MotionCard>
-      </section>
+          </MotionCard>
+        </section>
+      )}
 
       {/* Gráficos */}
       <section className="grid gap-4 lg:grid-cols-3">
         <div className="lg:col-span-2">
-          <div className="rounded-xl border bg-white dark:bg-slate-900 p-4">
-            <h3 className="font-medium mb-3">Saldo mensal</h3>
-            <div className="h-[320px]">
-              <ResponsiveContainer>
-                <AreaChart data={curveData}>
-                  <XAxis dataKey="mes" />
-                  <YAxis />
-                  <Tooltip
-                    formatter={(v: number) =>
-                      (Number(v) || 0).toLocaleString('pt-BR', {
-                        style: 'currency',
-                        currency: 'BRL',
-                      })
-                    }
-                  />
-                  <Area type="monotone" dataKey="saldo" stroke="#10b981" fill="#10b98133" />
-                </AreaChart>
-              </ResponsiveContainer>
+          {loading ? (
+            <Skeleton className="h-72 w-full" />
+          ) : monthsTable.some(
+              (m) => m.balance !== 0 || m.income !== 0 || m.expense !== 0,
+            ) ? (
+            <div className="rounded-xl border bg-white dark:bg-slate-900 p-4">
+              <h3 className="font-medium mb-3">Saldo mensal</h3>
+              <div className="h-[320px]">
+                <ResponsiveContainer>
+                  <AreaChart data={curveData}>
+                    <XAxis dataKey="mes" />
+                    <YAxis />
+                    <Tooltip
+                      formatter={(v: number) =>
+                        (Number(v) || 0).toLocaleString("pt-BR", {
+                          style: "currency",
+                          currency: "BRL",
+                        })
+                      }
+                    />
+                    <Area
+                      type="monotone"
+                      dataKey="saldo"
+                      stroke="#10b981"
+                      fill="#10b98133"
+                    />
+                  </AreaChart>
+                </ResponsiveContainer>
+              </div>
             </div>
-          </div>
+          ) : (
+            <EmptyState
+              icon={<TrendingUp className="h-6 w-6" />}
+              title="Sem dados"
+            />
+          )}
         </div>
         <div className="lg:col-span-1">
-          <CategoryDonut categoriesData={categoriesData} />
+          {loading ? (
+            <Skeleton className="h-72 w-full" />
+          ) : summary && summary.byCategory.length > 0 ? (
+            <CategoryDonut categoriesData={summary.byCategory} />
+          ) : (
+            <EmptyState
+              icon={<TrendingDown className="h-6 w-6" />}
+              title="Sem dados"
+            />
+          )}
         </div>
       </section>
 
-      {loading && <p>Carregando…</p>}
       {error && <p className="text-red-600">{error}</p>}
 
       {/* Tabela por mês */}
-      <div className="rounded-xl border bg-white dark:bg-slate-900 p-4">
-        <Table>
-          <TableHeader>
-            <TableRow>
-              <TableHead>Mês</TableHead>
-              <TableHead className="text-right">Entradas</TableHead>
-              <TableHead className="text-right">Saídas</TableHead>
-              <TableHead className="text-right">Saldo</TableHead>
-              <TableHead />
-            </TableRow>
-          </TableHeader>
-          <TableBody>
-            {monthsTable.map((m) => {
-              const mes = dayjs(`${year}-${String(m.month).padStart(2, '0')}-01`).format('MMMM');
-              const label = mes.charAt(0).toUpperCase() + mes.slice(1);
-              const linkMes = `${year}-${String(m.month).padStart(2, '0')}`;
-              return (
-                <TableRow key={m.month}>
-                  <TableCell>{label}</TableCell>
-                  <TableCell className="text-right">
-                    {(Number(m.income) || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    {(Number(m.expense) || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    {(Number(m.balance) || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
-                  </TableCell>
-                  <TableCell className="text-right">
-                    <Button asChild size="sm" variant="outline">
-                      <Link to={`/financas/mensal?mes=${linkMes}`}>Ver mês</Link>
-                    </Button>
-                  </TableCell>
-                </TableRow>
-              );
-            })}
-          </TableBody>
-        </Table>
-      </div>
+      {loading ? (
+        <Skeleton className="h-64 w-full" />
+      ) : (
+        <div className="rounded-xl border bg-white dark:bg-slate-900 p-4">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Mês</TableHead>
+                <TableHead className="text-right">Entradas</TableHead>
+                <TableHead className="text-right">Saídas</TableHead>
+                <TableHead className="text-right">Saldo</TableHead>
+                <TableHead />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {monthsTable.map((m) => {
+                const mes = dayjs(
+                  `${year}-${String(m.month).padStart(2, "0")}-01`,
+                ).format("MMMM");
+                const label = mes.charAt(0).toUpperCase() + mes.slice(1);
+                const linkMes = `${year}-${String(m.month).padStart(2, "0")}`;
+                return (
+                  <TableRow key={m.month}>
+                    <TableCell>{label}</TableCell>
+                    <TableCell className="text-right">
+                      {(Number(m.income) || 0).toLocaleString("pt-BR", {
+                        style: "currency",
+                        currency: "BRL",
+                      })}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {(Number(m.expense) || 0).toLocaleString("pt-BR", {
+                        style: "currency",
+                        currency: "BRL",
+                      })}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      {(Number(m.balance) || 0).toLocaleString("pt-BR", {
+                        style: "currency",
+                        currency: "BRL",
+                      })}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <Button asChild size="sm" variant="outline">
+                        <Link to={`/financas/mensal?mes=${linkMes}`}>
+                          Ver mês
+                        </Link>
+                      </Button>
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </div>
+      )}
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- add yearly aggregation helper
- build annual finances page with KPIs, charts and monthly links
- update category donut to accept aggregated data

## Testing
- `npx eslint src/hooks/useTransactions.ts src/pages/FinancasAnual.tsx src/components/charts/CategoryDonut.tsx`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689cb486b5d083228d3a4650556459f6