### PR TITLE
feat: add account and card hooks with limits

### DIFF
--- a/src/components/ModalTransacao.tsx
+++ b/src/components/ModalTransacao.tsx
@@ -1,4 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
+
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -9,7 +11,6 @@ import SourcePicker, { type SourceValue } from '@/components/SourcePicker';
 import { useCategories } from '@/hooks/useCategories';
 import { useAccounts } from '@/hooks/useAccounts';
 import { useCreditCards } from '@/hooks/useCreditCards';
-import { toast } from 'sonner';
 import MoneyInput from '@/components/MoneyInput';
 
 // --- Types -----------------------------------------------------------------
@@ -179,7 +180,13 @@ export function ModalTransacao({ open, onClose, initialData, onSubmit }: Props) 
     let label: string | null = null;
     if (s.kind === 'account' && s.id) label = findAccount(s.id)?.name || null;
     if (s.kind === 'card' && s.id) label = cardsById.get(s.id)?.name || null;
-    setForm(prev => ({ ...prev, source_kind: s.kind, source_id: s.id ?? null, source_label: label }));
+    setForm(prev => ({
+      ...prev,
+      source_kind: s.kind,
+      source_id: s.id ?? null,
+      source_label: label,
+      installments: s.kind === 'card' ? prev.installments : null,
+    }));
   }, [cardsById, findAccount]);
 
   return (

--- a/src/components/SourcePicker.tsx
+++ b/src/components/SourcePicker.tsx
@@ -1,15 +1,15 @@
 import { useEffect, useMemo, useState, useId } from "react";
+import { Wallet, CreditCard, Plus } from "lucide-react";
+import { toast } from "sonner";
+
 import { useAccounts } from "@/hooks/useAccounts";
 import { useCreditCards, cycleFor as cardCycleFor } from "@/hooks/useCreditCards";
-import { Wallet, CreditCard, Plus } from "lucide-react";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { toast } from "sonner";
-
-import type { CreditCard as CardModel } from "@/hooks/useCreditCards";
+import type { Card } from "@/hooks/useCreditCards";
 
 export type SourceValue = { kind: "account" | "card"; id: string | null };
 
@@ -59,7 +59,7 @@ export default function SourcePicker({
 
   const cardHint = useMemo(() => {
     if (!showCardHints || kind !== "card" || !selectedId) return null;
-    const cc: CardModel | undefined = cardsById.get(selectedId);
+    const cc: Card | undefined = cardsById.get(selectedId);
     if (!cc) return null;
     const cyc = cardCycleFor(cc);
     if (!cyc) return null;
@@ -138,15 +138,15 @@ export default function SourcePicker({
             <SelectItem value="">Todas</SelectItem>
             {cards.map((c) => (
               <SelectItem key={c.id} value={c.id}>
-                  <span className="inline-flex items-center gap-2">
-                    <span className="h-2.5 w-2.5 rounded-full bg-sky-500" />
-                    <span className="font-medium">{c.name}</span>
-                    {typeof c.limit_amount === "number" && (
-                      <span className="ml-1 text-xs opacity-70">limite {brl(c.limit_amount)}</span>
-                    )}
-                  </span>
-                </SelectItem>
-              ))}
+                <span className="inline-flex items-center gap-2">
+                  <span className="h-2.5 w-2.5 rounded-full bg-sky-500" />
+                  <span className="font-medium">{c.name}</span>
+                  {typeof c.limit === "number" && (
+                    <span className="ml-1 text-xs opacity-70">limite {brl(c.limit)}</span>
+                  )}
+                </span>
+              </SelectItem>
+            ))}
             </SelectContent>
           </Select>
           {cardHint && (

--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -1,27 +1,28 @@
 import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
 import {
-  Table, TableBody, TableCell, TableHead, TableHeader, TableRow
-} from '@/components/ui/table';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import {
   Pencil, Trash2, ChevronLeft, ChevronRight, ArrowUpDown, Wallet, CreditCard,
   Upload, Download, Copy, CheckSquare, Square, Plus
 } from 'lucide-react';
 import dayjs from 'dayjs';
+import { toast } from 'sonner';
+
+import {
+  Table, TableBody, TableCell, TableHead, TableHeader, TableRow
+} from '@/components/ui/table';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
-import { toast } from 'sonner';
 import { useAccounts } from '@/hooks/useAccounts';
 import { useCreditCards } from '@/hooks/useCreditCards';
 import type { Account } from '@/hooks/useAccounts';
-import type { CreditCard as CardModel } from '@/hooks/useCreditCards';
+import type { Card } from '@/hooks/useCreditCards';
 import { Badge } from '@/components/ui/badge';
 
 // Tipo de linha exibida na tabela (shape de UI vindo de FinancasMensal)
 type SourceRef =
   | { kind: 'account'; id: string; entity?: Account }
-  | { kind: 'card'; id: string; entity?: CardModel };
+  | { kind: 'card'; id: string; entity?: Card };
 
 export type UITransaction = {
   id: number;
@@ -398,7 +399,7 @@ export default function TransactionsTable({
                           const card = cardsById.get(ref.id);
                           const name = card?.name || t.card_name || t.source_name || 'Cartão';
                           const short = name.length > 12 ? name.slice(0, 12) + '…' : name;
-                          const brand = card?.brand || card?.bank;
+                          const brand = card?.brand;
                           return (
                             <Tooltip>
                               <TooltipTrigger asChild>

--- a/src/hooks/useAccounts.ts
+++ b/src/hooks/useAccounts.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+
 import { supabase } from "@/lib/supabaseClient";
 
 export type Account = {
@@ -16,6 +17,8 @@ export type Account = {
 function sanitize(payload: Partial<Account>) {
   const p: Partial<Account> = { ...payload };
   if (typeof p.name === "string") p.name = p.name.trim();
+  if (typeof p.institution === "string") p.institution = p.institution.trim() || null;
+  if (p.balance !== undefined && p.balance !== null) p.balance = Number(p.balance);
   return p;
 }
 
@@ -123,8 +126,11 @@ export function useAccounts() {
     } as const;
   }, [data]);
 
+  const byId = useMemo(() => new Map(data.map((a) => [a.id, a])), [data]);
+
   return {
     data,
+    byId,
     grouped,
     loading,
     error,

--- a/src/hooks/useCreditCards.ts
+++ b/src/hooks/useCreditCards.ts
@@ -1,19 +1,19 @@
 import { useEffect, useState, useCallback, useMemo } from "react";
+
 import { supabase } from "@/lib/supabaseClient";
 
-export type CreditCard = {
+export type Card = {
   id: string;
   name: string;
   brand?: "visa" | "mastercard" | "elo" | "amex" | "hipercard" | string | null;
-  limit_amount?: number | null;
   last4?: string | null;
-  color?: string | null;
-  created_at?: string;
-  // campos legados ainda usados
-  bank?: string | null;
-  cut_day?: number | null;
+  limit?: number | null;
+  closing_day?: number | null;
   due_day?: number | null;
+  created_at?: string;
+  // campos extras/legados ainda usados em partes do app
   account_id?: string | null;
+  color?: string | null;
 };
 
 // ------- helpers internos -------
@@ -23,33 +23,33 @@ function clampDay(n: unknown): number | null {
   return Number.isFinite(v) ? v : null;
 }
 
-function sanitize(payload: Partial<CreditCard>) {
-  const p: Partial<CreditCard> = { ...payload };
+function sanitize(payload: Partial<Card>) {
+  const p: Partial<Card> = { ...payload };
   if (typeof p.name === "string") p.name = p.name.trim();
-  if (p.cut_day !== undefined) p.cut_day = clampDay(p.cut_day);
+  if (typeof p.brand === "string") p.brand = p.brand.trim();
+  if (p.closing_day !== undefined) p.closing_day = clampDay(p.closing_day);
   if (p.due_day !== undefined) p.due_day = clampDay(p.due_day);
-  // bank / account_id podem vir null/undefined
   return p;
 }
 
 /**
  * Calcula o ciclo de fatura para uma data de referência.
- * Regra comum: o ciclo vai do dia (cut_day + 1) do mês anterior até o cut_day do mês corrente.
- * O vencimento é no due_day do mês corrente (ou próximo mês se due_day <= cut_day, conforme bancos).
+ * Regra comum: o ciclo vai do dia (closing_day + 1) do mês anterior até o closing_day do mês corrente.
+ * O vencimento é no due_day do mês corrente (ou próximo mês se due_day <= closing_day, conforme bancos).
  */
-export function cycleFor(card: Pick<CreditCard, "cut_day" | "due_day">, refDate: Date | string = new Date()) {
-  const cut = clampDay(card.cut_day);
+export function cycleFor(card: Pick<Card, "closing_day" | "due_day">, refDate: Date | string = new Date()) {
+  const cut = clampDay(card.closing_day);
   const due = clampDay(card.due_day);
   const d = new Date(refDate);
   if (!cut) return null;
 
-  // end (fechamento) = dia cut do mês de ref
+  // end (fechamento) = dia closing_day do mês de ref
   const end = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), cut));
-  // start = dia seguinte ao cut do mês anterior
+  // start = dia seguinte ao closing_day do mês anterior
   const start = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() - 1, cut));
   start.setUTCDate(start.getUTCDate() + 1);
 
-  // dueDate: se due existir, usa o mês seguinte ao fechamento quando due <= cut (prática comum)
+  // dueDate: se due existir, usa o mês seguinte ao fechamento quando due <= closing_day
   let dueDate: Date | null = null;
   if (due) {
     const base = new Date(end);
@@ -69,15 +69,15 @@ export function cycleFor(card: Pick<CreditCard, "cut_day" | "due_day">, refDate:
 }
 
 export function useCreditCards() {
-  const [data, setData] = useState<CreditCard[]>([]);
+  const [data, setData] = useState<Card[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const list = useCallback(async (): Promise<CreditCard[]> => {
+  const list = useCallback(async (): Promise<Card[]> => {
     setLoading(true);
     setError(null);
-      const { data: rows, error } = await supabase
-        .from("credit_cards")
+    const { data: rows, error } = await supabase
+      .from("credit_cards")
       .select("*")
       .order("name", { ascending: true });
     if (error) {
@@ -86,47 +86,70 @@ export function useCreditCards() {
       setLoading(false);
       return [];
     }
-    setData(rows ?? []);
+    const mapped = (rows ?? []).map((r: any) => ({
+      ...r,
+      limit: r.limit ?? r.limit_amount ?? null,
+      closing_day: r.closing_day ?? r.cut_day ?? null,
+    })) as Card[];
+    setData(mapped);
     setLoading(false);
-    return rows ?? [];
+    return mapped;
   }, []);
 
   useEffect(() => { void list(); }, [list]);
 
   // ---------- CRUD ----------
   const create = useCallback(
-    async (payload: Omit<CreditCard, "id" | "created_at">): Promise<CreditCard> => {
+    async (payload: Omit<Card, "id" | "created_at">): Promise<Card> => {
       const base = sanitize(payload);
-        const { data: row, error } = await supabase
-          .from("credit_cards")
-        .insert(base)
+      const db: any = { ...base };
+      if (db.limit !== undefined) { db.limit_amount = db.limit; delete db.limit; }
+      if (db.closing_day !== undefined) { db.cut_day = db.closing_day; delete db.closing_day; }
+      const { data: row, error } = await supabase
+        .from("credit_cards")
+        .insert(db)
         .select("*")
         .single();
       if (error) throw error;
-      setData((d) => [...d, row]);
-      return row;
+      const mapped: Card = {
+        ...row,
+        limit: (row as any).limit ?? (row as any).limit_amount ?? null,
+        closing_day: (row as any).closing_day ?? (row as any).cut_day ?? null,
+      };
+      setData(d => [...d, mapped]);
+      return mapped;
     },
     []
   );
 
   const update = useCallback(
-    async (id: string, patch: Partial<Omit<CreditCard, "id">>): Promise<void> => {
+    async (id: string, patch: Partial<Omit<Card, "id">>): Promise<void> => {
       const upd = sanitize(patch);
-        const { error } = await supabase
-          .from("credit_cards")
-        .update(upd)
-        .eq("id", id);
+      const db: any = { ...upd };
+      if (db.limit !== undefined) { db.limit_amount = db.limit; delete db.limit; }
+      if (db.closing_day !== undefined) { db.cut_day = db.closing_day; delete db.closing_day; }
+      const { data: row, error } = await supabase
+        .from("credit_cards")
+        .update(db)
+        .eq("id", id)
+        .select("*")
+        .single();
       if (error) throw error;
-      await list();
+      const mapped: Card = {
+        ...row,
+        limit: (row as any).limit ?? (row as any).limit_amount ?? null,
+        closing_day: (row as any).closing_day ?? (row as any).cut_day ?? null,
+      };
+      setData(d => d.map(c => (c.id === id ? mapped : c)));
     },
-    [list]
+    []
   );
 
   const remove = useCallback(
     async (id: string): Promise<void> => {
       const { error } = await supabase.from("credit_cards").delete().eq("id", id);
       if (error) throw error;
-      setData((d) => d.filter((c) => c.id !== id));
+      setData(d => d.filter(c => c.id !== id));
     },
     []
   );
@@ -136,18 +159,18 @@ export function useCreditCards() {
       if (!ids.length) return;
       const { error } = await supabase.from("credit_cards").delete().in("id", ids);
       if (error) throw error;
-      setData((d) => d.filter((c) => !ids.includes(c.id)));
+      setData(d => d.filter(c => !ids.includes(c.id)));
     },
     []
   );
 
   const upsert = useCallback(
-    async (payload: Partial<CreditCard>) => {
+    async (payload: Partial<Card>) => {
       if (payload.id) {
         const { id, ...rest } = payload;
         return update(id, rest);
       }
-      return create(payload as Omit<CreditCard, "id" | "created_at">);
+      return create(payload as Omit<Card, "id" | "created_at">);
     },
     [create, update]
   );
@@ -157,20 +180,20 @@ export function useCreditCards() {
   const findByName = useCallback((name: string) => data.find(c => c.name === name) ?? null, [data]);
 
   const setLimit = useCallback(
-    async (id: string, limit_amount: number | null) => update(id, { limit_amount }),
-    [update]
+    async (id: string, limit: number | null) => update(id, { limit }),
+    [update],
   );
-  const setCutDue = useCallback(
-    async (id: string, cut_day: number | null, due_day: number | null) =>
-      update(id, { cut_day, due_day }),
-    [update]
+  const setDays = useCallback(
+    async (id: string, closing_day: number | null, due_day: number | null) =>
+      update(id, { closing_day, due_day }),
+    [update],
   );
   const attachAccount = useCallback(
     async (id: string, account_id: string | null) => update(id, { account_id }),
-    [update]
+    [update],
   );
 
-  const byId = useMemo(() => new Map(data.map((c) => [c.id, c])), [data]);
+  const byId = useMemo(() => new Map(data.map(c => [c.id, c])), [data]);
 
   return {
     data,
@@ -186,8 +209,9 @@ export function useCreditCards() {
     findById,
     findByName,
     setLimit,
-    setCutDue,
+    setDays,
     attachAccount,
     cycleFor,
   } as const;
 }
+


### PR DESCRIPTION
## Summary
- extend accounts hook with input sanitization and quick lookup map
- introduce Card hook with limit and billing cycle support
- update pickers and transaction UI to work with accounts/cards and limits

## Testing
- `npm run lint` *(fails: import/order errors)*
- `npm run typecheck`
- `npm test` *(fails: missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_689cb49d306483229436ce462b547f8e