### PR TITLE
feat: add miles module pages with themed header

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import { Toaster } from 'sonner';
 
 /* ---------- Contexto de Autenticação ---------- */
 import { AuthProvider, useAuth } from './contexts/AuthContext';
-
 /* ---------- Componentes ---------- */
 import { Sidebar } from './components/Sidebar';
 import { AppHotkeys } from "./components/AppHotkeys";
@@ -26,6 +25,7 @@ const CarteiraCripto    = lazy(() => import('./pages/CarteiraCripto'));
 
 const Metas = lazy(() => import('./pages/Metas'));
 
+const MilhasHome   = lazy(() => import('./pages/MilhasHome'));
 const MilhasLivelo = lazy(() => import('./pages/MilhasLivelo'));
 const MilhasLatam  = lazy(() => import('./pages/MilhasLatam'));
 const MilhasAzul   = lazy(() => import('./pages/MilhasAzul'));
@@ -94,8 +94,9 @@ function AppRoutes() {
             <Route path="/metas" element={<Metas />} />
 
             {/* Milhas */}
+            <Route path="/milhas"           element={<MilhasHome />} />
             <Route path="/milhas/livelo"    element={<MilhasLivelo />} />
-            <Route path="/milhas/latampass" element={<MilhasLatam />} />
+            <Route path="/milhas/latam"     element={<MilhasLatam />} />
             <Route path="/milhas/azul"      element={<MilhasAzul />} />
 
             {/* Listas */}

--- a/src/components/BrandBadge.tsx
+++ b/src/components/BrandBadge.tsx
@@ -1,10 +1,10 @@
 
-export type MilesBrand = 'livelo' | 'latampass' | 'azul';
+export type MilesBrand = 'livelo' | 'latam' | 'azul';
 
 export const BRAND_STYLE: Record<MilesBrand, { bg: string; text: string; label: string }> = {
-  livelo:    { bg: 'from-fuchsia-600 to-pink-500', text: 'text-white',      label: 'Livelo' },
-  latampass: { bg: 'from-rose-600 to-purple-600',   text: 'text-white',      label: 'LATAM Pass' },
-  azul:      { bg: 'from-sky-600 to-blue-700',      text: 'text-white',      label: 'Azul' },
+  livelo: { bg: 'from-fuchsia-600 to-pink-500', text: 'text-white', label: 'Livelo' },
+  latam:  { bg: 'from-rose-600 to-purple-600',   text: 'text-white', label: 'LATAM Pass' },
+  azul:   { bg: 'from-sky-600 to-blue-700',      text: 'text-white', label: 'Azul' },
 };
 
 export function BrandBadge({ brand, className='' }: { brand: MilesBrand; className?: string }) {

--- a/src/components/MilesHeader.tsx
+++ b/src/components/MilesHeader.tsx
@@ -1,6 +1,8 @@
 import type { ReactNode } from 'react';
 import { Icon } from '@iconify/react';
 
+import PageHeader from '@/components/PageHeader';
+
 export type MilesProgram = 'livelo' | 'latam' | 'azul';
 
 const PROGRAM: Record<MilesProgram, { label: string; icon: string; gradient: string }> = {
@@ -12,19 +14,12 @@ const PROGRAM: Record<MilesProgram, { label: string; icon: string; gradient: str
 export default function MilesHeader({ program, subtitle, children }: { program: MilesProgram; subtitle?: string; children?: ReactNode }) {
   const cfg = PROGRAM[program];
   return (
-    <header className={`mb-6 rounded-xl bg-gradient-to-r ${cfg.gradient} text-white`}>
-      <div className="container mx-auto px-4 py-5 flex items-center justify-between gap-4">
-        <div className="flex items-center gap-3 min-w-0">
-          <Icon icon={cfg.icon} className="h-7 w-7 shrink-0" />
-          <div className="min-w-0">
-            <h1 className="text-xl font-semibold">Milhas — {cfg.label}</h1>
-            {subtitle ? (
-              <p className="text-white/80 text-sm leading-relaxed truncate">{subtitle}</p>
-            ) : null}
-          </div>
-        </div>
-        {children ? <div className="shrink-0">{children}</div> : null}
-      </div>
-    </header>
+    <PageHeader
+      title={`Milhas — ${cfg.label}`}
+      subtitle={subtitle}
+      icon={<Icon icon={cfg.icon} className="h-7 w-7 shrink-0" />}
+      actions={children}
+      gradient={cfg.gradient}
+    />
   );
 }

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -6,12 +6,13 @@ export type Breadcrumb = { label: string; href?: string };
 export type PageHeaderProps = {
   title: string; subtitle?: string; icon?: ReactNode;
   actions?: ReactNode; breadcrumbs?: Breadcrumb[]; children?: ReactNode;
+  gradient?: string;
 };
 
 const PageHeader = (props: PageHeaderProps) => {
-  const { title, subtitle, icon, actions, breadcrumbs, children } = props;
+  const { title, subtitle, icon, actions, breadcrumbs, children, gradient } = props;
   return (
-    <div className="mb-6 rounded-xl bg-gradient-to-r from-emerald-900 to-teal-700 text-white">
+    <div className={`mb-6 rounded-xl bg-gradient-to-r ${gradient ?? 'from-emerald-900 to-teal-700'} text-white`}>
       <div className="container mx-auto px-4 py-5 flex items-center justify-between gap-4">
         <div className="flex items-center gap-3 min-w-0">
           {icon ? <div className="rounded-lg bg-white/10 p-2 shrink-0">{icon}</div> : null}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -6,6 +6,7 @@ import {
   CandlestickChart, Coins, Target, Plane, Gift, ShoppingCart, Settings,
   ChevronDown, ChevronsLeft, ChevronsRight,
 } from "lucide-react";
+
 import { Logo } from "./Logo";
 import { ThemeToggle } from "./ThemeToggle";
 
@@ -50,7 +51,7 @@ const sections: Section[] = [
         type: "group", label: "Milhas", icon: Plane,
         children: [
           { type: "item", label: "Livelo", to: "/milhas/livelo", icon: Plane },
-          { type: "item", label: "Latam Pass", to: "/milhas/latampass", icon: Plane },
+          { type: "item", label: "Latam Pass", to: "/milhas/latam", icon: Plane },
           { type: "item", label: "Azul", to: "/milhas/azul", icon: Plane },
         ],
       },

--- a/src/pages/MilhasAzul.tsx
+++ b/src/pages/MilhasAzul.tsx
@@ -1,4 +1,5 @@
-import MilhasLivelo from './MilhasLivelo';
+import { MilhasProgram } from './MilhasLivelo';
+
 export default function MilhasAzul() {
-  return <MilhasLivelo />;
+  return <MilhasProgram program="azul" />;
 }

--- a/src/pages/MilhasHome.tsx
+++ b/src/pages/MilhasHome.tsx
@@ -1,7 +1,8 @@
 import { Link } from 'react-router-dom';
+import { Plane } from 'lucide-react';
+
 import PageHeader from '@/components/PageHeader';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
-import { Plane } from 'lucide-react';
 
 export default function MilhasHome() {
   const saldoTotal = 12000;

--- a/src/pages/MilhasLatam.tsx
+++ b/src/pages/MilhasLatam.tsx
@@ -1,7 +1,5 @@
-import MilhasLivelo from './MilhasLivelo';
+import { MilhasProgram } from './MilhasLivelo';
+
 export default function MilhasLatam() {
-  // Reuso rápido: mesma página, trocando somente o título/badge
-  // Para personalizar (cores/regras), podemos separar depois.
-  // Como atalho, apenas exporto a versão reutilizada e você muda o título no PageHeader.
-  return <MilhasLivelo />;
+  return <MilhasProgram program="latam" />;
 }

--- a/src/pages/MilhasLivelo.tsx
+++ b/src/pages/MilhasLivelo.tsx
@@ -1,18 +1,18 @@
 import { useMemo, useState } from 'react';
 import dayjs from 'dayjs';
 import 'dayjs/locale/pt-br';
+import { toast } from 'sonner';
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
 
-import MilesHeader from '@/components/MilesHeader';
+import MilesHeader, { type MilesProgram } from '@/components/MilesHeader';
 import { MotionCard } from '@/components/ui/MotionCard';
 import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
 import { Button } from '@/components/ui/button';
 import ModalMilesMovement, { type MilesMovement } from '@/components/ModalMilesMovement';
-import { toast } from 'sonner';
-import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
 
 dayjs.locale('pt-br');
 
-export default function MilhasLivelo() {
+export function MilhasProgram({ program }: { program: MilesProgram }) {
   const [open, setOpen] = useState(false);
   const [edit, setEdit] = useState<MilesMovement | null>(null);
 
@@ -63,7 +63,7 @@ export default function MilhasLivelo() {
 
   return (
     <div className="space-y-6">
-      <MilesHeader program="livelo" subtitle="Saldo, expiração e movimentos">
+      <MilesHeader program={program} subtitle="Saldo, expiração e movimentos">
         <Button onClick={()=>{ setEdit(null); setOpen(true); }}>Novo movimento</Button>
       </MilesHeader>
 
@@ -130,4 +130,8 @@ export default function MilhasLivelo() {
       />
     </div>
   );
+}
+
+export default function MilhasLivelo() {
+  return <MilhasProgram program="livelo" />;
 }


### PR DESCRIPTION
## Summary
- style header with program-specific gradients and icons
- add miles pages for Livelo, LATAM and Azul with movement dialog
- expose `/milhas` routes and sidebar links for each program

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/PageHeader.tsx src/components/MilesHeader.tsx src/components/BrandBadge.tsx src/components/Sidebar.tsx src/pages/MilhasHome.tsx src/pages/MilhasLivelo.tsx src/pages/MilhasLatam.tsx src/pages/MilhasAzul.tsx src/App.tsx`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689cb4b82708832290758c2d9493cd48