### PR TITLE
chore: enforce consistent import ordering

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,18 @@ export default tseslint.config([
     plugins: {
       import: pluginImport,
     },
+    settings: {
+      'import/resolver': {
+        typescript: {
+          project: [
+            './tsconfig.json',
+            './tsconfig.app.json',
+            './tsconfig.node.json',
+          ],
+          alwaysTryTypes: true,
+        },
+      },
+    },
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
@@ -32,17 +44,37 @@ export default tseslint.config([
       'import/order': [
         'error',
         {
+          alphabetize: { order: 'asc', caseInsensitive: true },
           'newlines-between': 'always',
+          distinctGroup: true,
           groups: [
             'builtin',
             'external',
             'internal',
-            'parent',
-            'sibling',
-            'index',
+            ['parent', 'sibling', 'index'],
+            'object',
+            'type',
           ],
+          pathGroups: [
+            {
+              pattern: 'react',
+              group: 'external',
+              position: 'before',
+            },
+            {
+              pattern: '@/**',
+              group: 'internal',
+            },
+          ],
+          pathGroupsExcludedImportTypes: ['react'],
         },
       ],
+    },
+  },
+  {
+    files: ['**/*.stories.*'],
+    rules: {
+      'import/order': 'off',
     },
   },
 ], storybook.configs["flat/recommended"]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,6 +57,7 @@
         "@vitest/coverage-v8": "^3.2.4",
         "autoprefixer": "^10.4.21",
         "eslint": "9.33.0",
+        "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.9",
@@ -459,10 +460,33 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.4.5.tgz",
+      "integrity": "sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.0.4",
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/runtime": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.4.5.tgz",
       "integrity": "sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.0.4.tgz",
+      "integrity": "sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1763,6 +1787,19 @@
       "peerDependencies": {
         "@types/react": ">=16",
         "react": ">=16"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
       }
     },
     "node_modules/@neoconfetti/react": {
@@ -3453,6 +3490,17 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.0.tgz",
+      "integrity": "sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
@@ -3955,6 +4003,275 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
+    },
+    "node_modules/@unrs/resolver-binding-android-arm-eabi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm-eabi/-/resolver-binding-android-arm-eabi-1.11.1.tgz",
+      "integrity": "sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-android-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-android-arm64/-/resolver-binding-android-arm64-1.11.1.tgz",
+      "integrity": "sha512-lCxkVtb4wp1v+EoN+HjIG9cIIzPkX5OtM03pQYkG+U5O/wL53LC4QbIeazgiKqluGeVEeBlZahHalCaBvU1a2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-arm64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-arm64/-/resolver-binding-darwin-arm64-1.11.1.tgz",
+      "integrity": "sha512-gPVA1UjRu1Y/IsB/dQEsp2V1pm44Of6+LWvbLc9SDk1c2KhhDRDBUkQCYVWe6f26uJb3fOK8saWMgtX8IrMk3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-darwin-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-darwin-x64/-/resolver-binding-darwin-x64-1.11.1.tgz",
+      "integrity": "sha512-cFzP7rWKd3lZaCsDze07QX1SC24lO8mPty9vdP+YVa3MGdVgPmFc59317b2ioXtgCMKGiCLxJ4HQs62oz6GfRQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-freebsd-x64": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-freebsd-x64/-/resolver-binding-freebsd-x64-1.11.1.tgz",
+      "integrity": "sha512-fqtGgak3zX4DCB6PFpsH5+Kmt/8CIi4Bry4rb1ho6Av2QHTREM+47y282Uqiu3ZRF5IQioJQ5qWRV6jduA+iGw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-gnueabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-gnueabihf/-/resolver-binding-linux-arm-gnueabihf-1.11.1.tgz",
+      "integrity": "sha512-u92mvlcYtp9MRKmP+ZvMmtPN34+/3lMHlyMj7wXJDeXxuM0Vgzz0+PPJNsro1m3IZPYChIkn944wW8TYgGKFHw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm-musleabihf": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm-musleabihf/-/resolver-binding-linux-arm-musleabihf-1.11.1.tgz",
+      "integrity": "sha512-cINaoY2z7LVCrfHkIcmvj7osTOtm6VVT16b5oQdS4beibX2SYBwgYLmqhBjA1t51CarSaBuX5YNsWLjsqfW5Cw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-gnu/-/resolver-binding-linux-arm64-gnu-1.11.1.tgz",
+      "integrity": "sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-arm64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-arm64-musl/-/resolver-binding-linux-arm64-musl-1.11.1.tgz",
+      "integrity": "sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-ppc64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-ppc64-gnu/-/resolver-binding-linux-ppc64-gnu-1.11.1.tgz",
+      "integrity": "sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-gnu/-/resolver-binding-linux-riscv64-gnu-1.11.1.tgz",
+      "integrity": "sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-riscv64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-riscv64-musl/-/resolver-binding-linux-riscv64-musl-1.11.1.tgz",
+      "integrity": "sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-s390x-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-s390x-gnu/-/resolver-binding-linux-s390x-gnu-1.11.1.tgz",
+      "integrity": "sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-gnu": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-gnu/-/resolver-binding-linux-x64-gnu-1.11.1.tgz",
+      "integrity": "sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-linux-x64-musl": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+      "integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-wasm32-wasi": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-wasm32-wasi/-/resolver-binding-wasm32-wasi-1.11.1.tgz",
+      "integrity": "sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.11"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@unrs/resolver-binding-win32-arm64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-arm64-msvc/-/resolver-binding-win32-arm64-msvc-1.11.1.tgz",
+      "integrity": "sha512-nRcz5Il4ln0kMhfL8S3hLkxI85BXs3o8EYoattsJNdsX4YUU89iOkVn7g0VHSRxFuVMdM4Q1jEpIId1Ihim/Uw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-ia32-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-ia32-msvc/-/resolver-binding-win32-ia32-msvc-1.11.1.tgz",
+      "integrity": "sha512-DCEI6t5i1NmAZp6pFonpD5m7i6aFrpofcp4LA2i8IIq60Jyo28hamKBxNrZcyOwVOZkgsRp9O2sXWBWP8MnvIQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@unrs/resolver-binding-win32-x64-msvc": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@unrs/resolver-binding-win32-x64-msvc/-/resolver-binding-win32-x64-msvc-1.11.1.tgz",
+      "integrity": "sha512-lrW200hZdbfRtztbygyaq/6jP6AKE8qQN2KvPcJ+x7wiD038YtnYtZ82IMNJ69GJibV7bwL3y9FgK+5w/pYt6g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.3.1",
@@ -5823,6 +6140,31 @@
         }
       }
     },
+    "node_modules/eslint-import-context": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-context/-/eslint-import-context-0.1.9.tgz",
+      "integrity": "sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-tsconfig": "^4.10.1",
+        "stable-hash-x": "^0.2.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-context"
+      },
+      "peerDependencies": {
+        "unrs-resolver": "^1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "unrs-resolver": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-import-resolver-node": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
@@ -5843,6 +6185,41 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-typescript": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-typescript/-/eslint-import-resolver-typescript-4.4.4.tgz",
+      "integrity": "sha512-1iM2zeBvrYmUNTj2vSC/90JTHDth+dfOfiNKkxApWRsTJYNrc8rOdxxIf5vazX+BiAXTeOT0UvWpGI/7qIWQOw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "debug": "^4.4.1",
+        "eslint-import-context": "^0.1.8",
+        "get-tsconfig": "^4.10.1",
+        "is-bun-module": "^2.0.0",
+        "stable-hash-x": "^0.2.0",
+        "tinyglobby": "^0.2.14",
+        "unrs-resolver": "^1.7.11"
+      },
+      "engines": {
+        "node": "^16.17.0 || >=18.6.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-import-resolver-typescript"
+      },
+      "peerDependencies": {
+        "eslint": "*",
+        "eslint-plugin-import": "*",
+        "eslint-plugin-import-x": "*"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-import": {
+          "optional": true
+        },
+        "eslint-plugin-import-x": {
+          "optional": true
+        }
       }
     },
     "node_modules/eslint-module-utils": {
@@ -7039,6 +7416,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-bun-module": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
+      "integrity": "sha512-gNCGbnnnnFAUGKeZ9PdbyeGYJqewpmc2aKHUEMO5nQPWU9lOmv7jcmQIv+qHD8fXW6W7qfuCwX4rY9LNRjXrkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.7.1"
+      }
+    },
+    "node_modules/is-bun-module/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -8179,6 +8579,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-postinstall": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/napi-postinstall/-/napi-postinstall-0.3.3.tgz",
+      "integrity": "sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "napi-postinstall": "lib/cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/napi-postinstall"
       }
     },
     "node_modules/natural-compare": {
@@ -9866,6 +10282,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stable-hash-x": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stable-hash-x/-/stable-hash-x-0.2.0.tgz",
+      "integrity": "sha512-o3yWv49B/o4QZk5ZcsALc6t0+eCelPc44zZsLtCQnZPDwFpDYSWcDnrv2TtMmMbQ7uKo3J0HTURCqckw23czNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/stackback": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
@@ -10818,6 +11244,41 @@
       },
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/unrs-resolver": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
+      "integrity": "sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "napi-postinstall": "^0.3.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/unrs-resolver"
+      },
+      "optionalDependencies": {
+        "@unrs/resolver-binding-android-arm-eabi": "1.11.1",
+        "@unrs/resolver-binding-android-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-arm64": "1.11.1",
+        "@unrs/resolver-binding-darwin-x64": "1.11.1",
+        "@unrs/resolver-binding-freebsd-x64": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-gnueabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm-musleabihf": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-arm64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-ppc64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-riscv64-musl": "1.11.1",
+        "@unrs/resolver-binding-linux-s390x-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-gnu": "1.11.1",
+        "@unrs/resolver-binding-linux-x64-musl": "1.11.1",
+        "@unrs/resolver-binding-wasm32-wasi": "1.11.1",
+        "@unrs/resolver-binding-win32-arm64-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-ia32-msvc": "1.11.1",
+        "@unrs/resolver-binding-win32-x64-msvc": "1.11.1"
       }
     },
     "node_modules/update-browserslist-db": {

--- a/package.json
+++ b/package.json
@@ -66,8 +66,11 @@
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
     "@vitejs/plugin-react": "4.3.1",
+    "@vitest/browser": "^3.2.4",
+    "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.21",
     "eslint": "9.33.0",
+    "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.9",
@@ -75,6 +78,7 @@
     "globals": "^16.3.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.1.5",
+    "playwright": "^1.54.2",
     "postcss": "^8.5.6",
     "prettier": "^3.3.3",
     "sharp": "^0.33.4",
@@ -83,12 +87,9 @@
     "tailwindcss": "^3.4.17",
     "ts-node": "^10.9.2",
     "tsx": "^4.20.3",
-    "typescript-eslint": "8.39.1",
     "typescript": "5.5.4",
+    "typescript-eslint": "8.39.1",
     "vite": "5.3.4",
-    "vitest": "^3.2.4",
-    "@vitest/browser": "^3.2.4",
-    "playwright": "^1.54.2",
-    "@vitest/coverage-v8": "^3.2.4"
+    "vitest": "^3.2.4"
   }
 }

--- a/scripts/codemod-rewrite-imports.ts
+++ b/scripts/codemod-rewrite-imports.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
+
 import ts from 'typescript'
 
 const DRY_RUN = process.argv.includes('--dry-run')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,15 @@
-import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { lazy, Suspense } from 'react';
+
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { Toaster } from 'sonner';
 
 /* ---------- Contexto de Autenticação ---------- */
+import { AppHotkeys } from "./components/AppHotkeys";
+import RouteLoader from './components/RouteLoader';
+import { Sidebar } from './components/Sidebar';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
 /* ---------- Componentes ---------- */
-import { Sidebar } from './components/Sidebar';
-import { AppHotkeys } from "./components/AppHotkeys";
 import { PeriodProvider } from './state/periodFilter';
-import RouteLoader from './components/RouteLoader';
 
 /* ---------- lazy imports de páginas ---------- */
 const Dashboard      = lazy(() => import('./pages/Dashboard'));

--- a/src/components/AppHotkeys.tsx
+++ b/src/components/AppHotkeys.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+
 import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 

--- a/src/components/CategoryPicker.tsx
+++ b/src/components/CategoryPicker.tsx
@@ -1,14 +1,8 @@
 import { useMemo, useState, useId } from "react";
+
 import { Plus, MoreHorizontal } from "lucide-react";
 import { toast } from "sonner";
 
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -17,14 +11,21 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useCategories, type Category } from "@/hooks/useCategories";
 
 type Props = {

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,7 +1,8 @@
 // src/components/FilterBar.tsx
 import { useCallback, type KeyboardEvent } from 'react';
-import { usePeriod } from "@/state/periodFilter";
+
 import { CalendarRange, Calendar } from "lucide-react";
+
 import {
   Select,
   SelectTrigger,
@@ -9,6 +10,7 @@ import {
   SelectContent,
   SelectItem,
 } from "@/components/ui/select";
+import { usePeriod } from "@/state/periodFilter";
 
 /**
  * Barra de filtro com selects premium (shadcn/ui) e navegação por teclado.

--- a/src/components/MilesHeader.tsx
+++ b/src/components/MilesHeader.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react';
+
 import { Icon } from '@iconify/react';
 
 import PageHeader from '@/components/PageHeader';

--- a/src/components/ModalAporteMeta.tsx
+++ b/src/components/ModalAporteMeta.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 

--- a/src/components/ModalCartao.tsx
+++ b/src/components/ModalCartao.tsx
@@ -1,15 +1,18 @@
 
 
 import { useMemo, useState } from "react";
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+
+import { toast } from "sonner";
+
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { useAccounts } from "@/hooks/useAccounts";
 import { useCreditCards, cycleFor } from "@/hooks/useCreditCards";
 import { supabase } from "@/lib/supabaseClient";
-import { toast } from "sonner";
+
 
 export type ModalCartaoProps = {
   open: boolean;

--- a/src/components/ModalConta.tsx
+++ b/src/components/ModalConta.tsx
@@ -1,8 +1,9 @@
 
 
 import * as React from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@/components/ui/select";
 import { useAccounts } from "@/hooks/useAccounts";

--- a/src/components/ModalInvest.tsx
+++ b/src/components/ModalInvest.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useMemo, useState, type KeyboardEvent } from "react";
+
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
@@ -7,9 +9,8 @@ import {
   DialogTitle,
   DialogDescription,
 } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Select,
   SelectTrigger,

--- a/src/components/ModalInvestimento.tsx
+++ b/src/components/ModalInvestimento.tsx
@@ -1,8 +1,8 @@
 // src/components/ModalInvestimento.tsx
 import { useEffect, useState } from 'react';
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';

--- a/src/components/ModalMeta.tsx
+++ b/src/components/ModalMeta.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@/components/ui/select";

--- a/src/components/ModalMilesMovement.tsx
+++ b/src/components/ModalMilesMovement.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
+
 import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@/components/ui/select";

--- a/src/components/ModalTransacao.tsx
+++ b/src/components/ModalTransacao.tsx
@@ -1,18 +1,19 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
+
 import { toast } from 'sonner';
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import CategoryPicker from '@/components/CategoryPicker';
+import MoneyInput from '@/components/MoneyInput';
+import ReceiptUpload from '@/components/ReceiptUpload';
+import SourcePicker, { type SourceValue } from '@/components/SourcePicker';
 import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
-import CategoryPicker from '@/components/CategoryPicker';
-import SourcePicker, { type SourceValue } from '@/components/SourcePicker';
-import { useCategories } from '@/hooks/useCategories';
 import { useAccounts } from '@/hooks/useAccounts';
+import { useCategories } from '@/hooks/useCategories';
 import { useCreditCards } from '@/hooks/useCreditCards';
-import MoneyInput from '@/components/MoneyInput';
-import ReceiptUpload from '@/components/ReceiptUpload';
 
 // --- Types -----------------------------------------------------------------
 export type BaseData = {

--- a/src/components/ReceiptUpload.tsx
+++ b/src/components/ReceiptUpload.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState, type ChangeEvent } from "react";
+
 import { toast } from "sonner";
 
 import { Button } from "@/components/ui/button";

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,11 +1,12 @@
 import * as React from "react";
-import { NavLink, useLocation, useNavigate } from "react-router-dom";
+
 import * as RTooltip from "@radix-ui/react-tooltip";
 import {
   LayoutDashboard, Wallet, CalendarRange, PiggyBank, Landmark, Building2,
   CandlestickChart, Coins, Target, Plane, Gift, ShoppingCart, Settings,
   ChevronDown, ChevronsLeft, ChevronsRight,
 } from "lucide-react";
+import { NavLink, useLocation, useNavigate } from "react-router-dom";
 
 import { Logo } from "./Logo";
 import { ThemeToggle } from "./ThemeToggle";

--- a/src/components/SourcePicker.tsx
+++ b/src/components/SourcePicker.tsx
@@ -1,14 +1,15 @@
 import { useEffect, useMemo, useState, useId } from "react";
+
 import { Wallet, CreditCard, Plus } from "lucide-react";
 import { toast } from "sonner";
 
-import { useAccounts } from "@/hooks/useAccounts";
-import { useCreditCards, cycleFor as cardCycleFor } from "@/hooks/useCreditCards";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { useAccounts } from "@/hooks/useAccounts";
+import { useCreditCards, cycleFor as cardCycleFor } from "@/hooks/useCreditCards";
 import type { Card } from "@/hooks/useCreditCards";
 
 export type SourceValue = { kind: "account" | "card"; id: string | null };

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+
 import { Moon, Sun } from "lucide-react";
 
 function getInitialTheme(): "light" | "dark" {

--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -1,23 +1,24 @@
 import { useEffect, useMemo, useRef, useState, type ChangeEvent } from 'react';
+
+import dayjs from 'dayjs';
 import {
   Pencil, Trash2, ChevronLeft, ChevronRight, ArrowUpDown, Wallet, CreditCard,
   Upload, Download, Copy, CheckSquare, Square, Plus
 } from 'lucide-react';
-import dayjs from 'dayjs';
 import { toast } from 'sonner';
 
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
 import {
   Table, TableBody, TableCell, TableHead, TableHeader, TableRow
 } from '@/components/ui/table';
-import { Input } from '@/components/ui/input';
-import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { useAccounts } from '@/hooks/useAccounts';
-import { useCreditCards } from '@/hooks/useCreditCards';
 import type { Account } from '@/hooks/useAccounts';
+import { useCreditCards } from '@/hooks/useCreditCards';
 import type { Card } from '@/hooks/useCreditCards';
-import { Badge } from '@/components/ui/badge';
 
 // Tipo de linha exibida na tabela (shape de UI vindo de FinancasMensal)
 type SourceRef =

--- a/src/components/charts/CategoryDonut.tsx
+++ b/src/components/charts/CategoryDonut.tsx
@@ -1,5 +1,7 @@
 // src/components/charts/CategoryDonut.tsx
 import { useMemo } from "react";
+import { useMemo } from 'react';
+
 import {
   PieChart,
   Pie,
@@ -8,14 +10,12 @@ import {
   Tooltip,
   Legend,
 } from "recharts";
-
-import { mapCategoryColor } from "@/lib/palette";
-import type { UITransaction } from "@/components/TransactionsTable";
-import { useMemo } from 'react';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
 
-import { mapCategoryColor } from '@/lib/palette';
+import type { UITransaction } from "@/components/TransactionsTable";
 import type { UITransaction } from '@/components/TransactionsTable';
+import { mapCategoryColor } from "@/lib/palette";
+import { mapCategoryColor } from '@/lib/palette';
 
 type Props = {
   transacoes?: UITransaction[];

--- a/src/components/charts/DailyBars.tsx
+++ b/src/components/charts/DailyBars.tsx
@@ -1,5 +1,7 @@
 // src/components/charts/DailyBars.tsx
 import { useMemo } from 'react';
+
+import dayjs from 'dayjs';
 import {
   BarChart,
   Bar,
@@ -10,10 +12,9 @@ import {
   Legend,
   LabelList,
 } from 'recharts';
-import dayjs from 'dayjs';
 
-import { SERIES_COLORS } from '@/lib/palette';
 import type { UITransaction } from '@/components/TransactionsTable';
+import { SERIES_COLORS } from '@/lib/palette';
 
 type Props = { transacoes?: UITransaction[]; mes?: string };
 

--- a/src/components/ui/AnimatedNumber.tsx
+++ b/src/components/ui/AnimatedNumber.tsx
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+
 import { motion, useSpring, useTransform } from 'framer-motion';
 
 export function AnimatedNumber({ value, currency=true }:{ value:number; currency?:boolean }) {

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from 'react'
+
 import { cn } from "@/lib/utils";
 
 interface EmptyStateProps {

--- a/src/components/ui/MotionCard.tsx
+++ b/src/components/ui/MotionCard.tsx
@@ -1,5 +1,6 @@
-import { motion } from 'framer-motion';
 import type { ReactNode } from 'react';
+
+import { motion } from 'framer-motion';
 
 export function MotionCard({ children, className='' }:{children:ReactNode; className?:string}) {
   return (

--- a/src/components/ui/Toasts.ts
+++ b/src/components/ui/Toasts.ts
@@ -1,6 +1,7 @@
 import { createElement } from 'react';
-import toast, { Toaster, type ToastOptions } from 'react-hot-toast';
+
 import { CheckCircle2, XCircle } from 'lucide-react';
+import toast, { Toaster, type ToastOptions } from 'react-hot-toast';
 
 const baseOptions: ToastOptions = {
   position: 'top-right',

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+
 import { cva, type VariantProps } from "class-variance-authority"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
 

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
 import { Check, ChevronRight, Circle } from "lucide-react"
 

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+
 import * as LabelPrimitive from "@radix-ui/react-label"
 import { cva, type VariantProps } from "class-variance-authority"
 

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+
 import * as ProgressPrimitive from "@radix-ui/react-progress"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+
 import * as SelectPrimitive from "@radix-ui/react-select"
 import { Check, ChevronDown, ChevronUp } from "lucide-react"
 

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -1,4 +1,5 @@
 import * as React from "react"
+
 import * as TabsPrimitive from "@radix-ui/react-tabs"
 
 import { cn } from "@/lib/utils"

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import * as React from "react"
+
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
 import { cn } from "@/lib/utils"

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,6 +1,8 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
+
 import { supabase } from '@/lib/supabaseClient';
+
 
 interface Ctx {
   user: string | null;

--- a/src/hooks/makeCrudHook.ts
+++ b/src/hooks/makeCrudHook.ts
@@ -1,7 +1,8 @@
 // src/hooks/makeCrudHook.ts
 import { useEffect, useState, useCallback } from 'react';
-import { supabase } from '@/lib/supabaseClient';
+
 import { useAuth } from '@/contexts/AuthContext';
+import { supabase } from '@/lib/supabaseClient';
 
 export function makeCrudHook<T extends { id: number }>(table: string) {
   return function useCrud(filter: Record<string, unknown> = {}) {

--- a/src/hooks/useBills.ts
+++ b/src/hooks/useBills.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
-import { supabase } from "@/lib/supabaseClient";
 import { buildSingleEvent } from "@/lib/ics";
+import { supabase } from "@/lib/supabaseClient";
 
 export type Bill = {
   id: string;

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 
-import { supabase } from "@/lib/supabaseClient";
 import { mapCategoryColor } from "@/lib/palette";
+import { supabase } from "@/lib/supabaseClient";
 
 export type Category = {
   id: string;

--- a/src/hooks/useGoals.ts
+++ b/src/hooks/useGoals.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
+
 import dayjs from 'dayjs';
+
 import { supabase } from '@/lib/supabaseClient';
 
 export type Goal = {

--- a/src/hooks/useInvestments.ts
+++ b/src/hooks/useInvestments.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+
 import dayjs from "dayjs";
 
 import { supabase } from "@/lib/supabaseClient";

--- a/src/hooks/useSuggestions.ts
+++ b/src/hooks/useSuggestions.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
+
 import { supabase } from "@/lib/supabaseClient";
 
 export type Suggestion = {

--- a/src/lib/brandMap.ts
+++ b/src/lib/brandMap.ts
@@ -1,5 +1,4 @@
 // src/lib/brandMap.ts
-import type { LucideIcon } from "lucide-react";
 import {
   Landmark,
   CreditCard,
@@ -11,6 +10,8 @@ import {
   Car,
   Music,
 } from "lucide-react";
+
+import type { LucideIcon } from "lucide-react";
 
 export type BrandKey =
   | "nubank"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,7 @@
 import { StrictMode } from 'react'
+
 import { createRoot } from 'react-dom/client'
+
 import App from './App'
 import AppErrorBoundary from './components/AppErrorBoundary'
 import { Toaster } from './components/ui/Toasts'

--- a/src/pages/Bills.tsx
+++ b/src/pages/Bills.tsx
@@ -1,8 +1,9 @@
 import { useMemo, useRef, useState } from "react";
 
-import PageHeader from "@/components/PageHeader";
 import FilterBar from "@/components/FilterBar";
+import PageHeader from "@/components/PageHeader";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
 import {
   Select,
   SelectContent,
@@ -11,9 +12,8 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Skeleton } from "@/components/ui/Skeleton";
-import { EmptyState } from "@/components/ui/EmptyState";
-import { usePeriod } from "@/state/periodFilter";
 import { useBills, type Bill } from "@/hooks/useBills";
+import { usePeriod } from "@/state/periodFilter";
 
 export default function Bills() {
   const { month, year } = usePeriod();

--- a/src/pages/CarteiraBolsa.tsx
+++ b/src/pages/CarteiraBolsa.tsx
@@ -1,14 +1,15 @@
 import { useMemo, useState } from "react";
+
 import dayjs from "dayjs";
 import { CandlestickChart, Plus } from "lucide-react";
 import { ResponsiveContainer, BarChart, Bar } from "recharts";
 
+import ModalInvestimento from "@/components/ModalInvestimento";
 import PageHeader from "@/components/PageHeader";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/Skeleton";
-import ModalInvestimento from "@/components/ModalInvestimento";
 import { useInvestments } from "@/hooks/useInvestments";
 
 const BRL = (v: number) =>

--- a/src/pages/CarteiraCripto.tsx
+++ b/src/pages/CarteiraCripto.tsx
@@ -1,14 +1,15 @@
 import { useMemo, useState } from "react";
+
 import dayjs from "dayjs";
 import { Coins, Plus } from "lucide-react";
 import { ResponsiveContainer, BarChart, Bar } from "recharts";
 
+import ModalInvestimento from "@/components/ModalInvestimento";
 import PageHeader from "@/components/PageHeader";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/Skeleton";
-import ModalInvestimento from "@/components/ModalInvestimento";
 import { useInvestments } from "@/hooks/useInvestments";
 
 const BRL = (v: number) =>

--- a/src/pages/CarteiraFIIs.tsx
+++ b/src/pages/CarteiraFIIs.tsx
@@ -1,14 +1,15 @@
 import { useMemo, useState } from "react";
+
 import dayjs from "dayjs";
 import { Building2, Plus } from "lucide-react";
 import { ResponsiveContainer, BarChart, Bar } from "recharts";
 
+import ModalInvestimento from "@/components/ModalInvestimento";
 import PageHeader from "@/components/PageHeader";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/Skeleton";
-import ModalInvestimento from "@/components/ModalInvestimento";
 import { useInvestments } from "@/hooks/useInvestments";
 
 const BRL = (v: number) =>

--- a/src/pages/CarteiraRendaFixa.tsx
+++ b/src/pages/CarteiraRendaFixa.tsx
@@ -1,14 +1,15 @@
 import { useMemo, useState } from "react";
+
 import dayjs from "dayjs";
 import { Landmark, Plus } from "lucide-react";
 import { ResponsiveContainer, BarChart, Bar } from "recharts";
 
+import ModalInvestimento from "@/components/ModalInvestimento";
 import PageHeader from "@/components/PageHeader";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Skeleton } from "@/components/ui/Skeleton";
-import ModalInvestimento from "@/components/ModalInvestimento";
 import { useInvestments } from "@/hooks/useInvestments";
 
 const BRL = (v: number) =>

--- a/src/pages/CarteiraTipo.tsx
+++ b/src/pages/CarteiraTipo.tsx
@@ -1,19 +1,20 @@
 // src/pages/CarteiraTipo.tsx
 import { useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
-import { supabase } from "@/lib/supabaseClient";
-import { useAuth } from "@/contexts/AuthContext";
-import PageHeader from "@/components/PageHeader";
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Plus, MoreHorizontal, Pencil, Trash2, Coins } from "lucide-react";
+import { toast } from "sonner";
+
+import PageHeader from "@/components/PageHeader";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
-import { Badge } from "@/components/ui/badge";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Plus, MoreHorizontal, Pencil, Trash2, Coins } from "lucide-react";
+import { useAuth } from "@/contexts/AuthContext";
+import { supabase } from "@/lib/supabaseClient";
 
 type Props = { tipo: "Renda fixa" | "FIIs" | "Ações" | "Cripto" | "Outros" };
 

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,19 @@
 import { useEffect, useMemo, useState, type ReactNode, type PropsWithChildren } from 'react';
-import { Link } from "react-router-dom";
+
 import { motion, useMotionValue, animate } from "framer-motion";
+import {
+  Wallet,
+  PiggyBank,
+  TrendingUp,
+  CreditCard,
+  ChevronRight,
+  Landmark,
+  CalendarRange,
+  Target,
+  Plane,
+  PieChart as PieChartIcon,
+} from "lucide-react";
+import { Link } from "react-router-dom";
 import {
   ResponsiveContainer,
   ComposedChart,
@@ -14,23 +27,12 @@ import {
   Cell,
   CartesianGrid,
 } from "recharts";
-import {
-  Wallet,
-  PiggyBank,
-  TrendingUp,
-  CreditCard,
-  ChevronRight,
-  Landmark,
-  CalendarRange,
-  Target,
-  Plane,
-  PieChart as PieChartIcon,
-} from "lucide-react";
+
 import BrandIcon from "@/components/BrandIcon";
 import FilterBar from "@/components/FilterBar";
-import { usePeriod } from "@/state/periodFilter";
-import { Skeleton } from "@/components/ui/Skeleton";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { usePeriod } from "@/state/periodFilter";
 
 // ---------------------------------- helpers
 const brl = (n: number) =>

--- a/src/pages/FinancasAnual.tsx
+++ b/src/pages/FinancasAnual.tsx
@@ -1,7 +1,9 @@
 import { useEffect, useMemo, useState } from "react";
+
 import dayjs from "dayjs";
 import "dayjs/locale/pt-br";
 import { Coins, TrendingUp, TrendingDown, CalendarRange } from "lucide-react";
+import { Link } from "react-router-dom";
 import {
   ResponsiveContainer,
   AreaChart,
@@ -10,11 +12,13 @@ import {
   YAxis,
   Tooltip,
 } from "recharts";
-import { Link } from "react-router-dom";
 
+import CategoryDonut from "@/components/charts/CategoryDonut";
 import PageHeader from "@/components/PageHeader";
-import { MotionCard } from "@/components/ui/MotionCard";
 import { AnimatedNumber } from "@/components/ui/AnimatedNumber";
+import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { MotionCard } from "@/components/ui/MotionCard";
 import {
   Select,
   SelectContent,
@@ -22,7 +26,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import CategoryDonut from "@/components/charts/CategoryDonut";
+import { Skeleton } from "@/components/ui/Skeleton";
 import {
   Table,
   TableBody,
@@ -31,10 +35,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-import { Button } from "@/components/ui/button";
 import { getYearSummary, type YearSummary } from "@/hooks/useTransactions";
-import { Skeleton } from "@/components/ui/Skeleton";
-import { EmptyState } from "@/components/ui/EmptyState";
 
 dayjs.locale("pt-br");
 

--- a/src/pages/FinancasMensal.tsx
+++ b/src/pages/FinancasMensal.tsx
@@ -1,30 +1,31 @@
 // src/pages/FinancasMensal.tsx
 import { useEffect, useMemo, useState } from 'react';
-import { useSearchParams } from 'react-router-dom';
+
 import dayjs from 'dayjs';
 import 'dayjs/locale/pt-br';
 import { Coins, TrendingUp, TrendingDown, Clock, Search, Plus, Download, CalendarRange, Copy } from 'lucide-react';
+import { useSearchParams } from 'react-router-dom';
 import { toast } from 'sonner';
 
-import { useTransactions, type Transaction, type TransactionInput } from '@/hooks/useTransactions';
+import CategoryPicker from '@/components/CategoryPicker';
+import CategoryDonut from '@/components/charts/CategoryDonut';
+import DailyBars from '@/components/charts/DailyBars';
 import { ModalTransacao, type BaseData } from '@/components/ModalTransacao';
 import PageHeader from '@/components/PageHeader';
-import { MotionCard } from '@/components/ui/MotionCard';
-import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
+import SourcePicker, { type SourceValue } from '@/components/SourcePicker';
 import TransactionsTable, { type UITransaction } from '@/components/TransactionsTable';
-import DailyBars from '@/components/charts/DailyBars';
-import CategoryDonut from '@/components/charts/CategoryDonut';
-// shadcn/ui
+import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { Input } from '@/components/ui/input';
+import { MotionCard } from '@/components/ui/MotionCard';
+// shadcn/ui
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select';
+import { Skeleton } from '@/components/ui/Skeleton';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from '@/components/ui/tooltip';
 import { useCategories } from '@/hooks/useCategories';
-import SourcePicker, { type SourceValue } from '@/components/SourcePicker';
-import CategoryPicker from '@/components/CategoryPicker';
-import { Skeleton } from '@/components/ui/Skeleton';
-import { EmptyState } from '@/components/ui/EmptyState';
+import { useTransactions, type Transaction, type TransactionInput } from '@/hooks/useTransactions';
 
 dayjs.locale('pt-br');
 

--- a/src/pages/Investimentos.tsx
+++ b/src/pages/Investimentos.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from "react";
+
 import dayjs from "dayjs";
 import {
   PieChart as PieIcon,
@@ -19,11 +20,11 @@ import {
 } from "recharts";
 
 import PageHeader from "@/components/PageHeader";
-import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
-import { useInvestments } from "@/hooks/useInvestments";
-import { Skeleton } from "@/components/ui/Skeleton";
-import { EmptyState } from "@/components/ui/EmptyState";
 import { Badge } from "@/components/ui/badge";
+import { Card, CardHeader, CardTitle, CardDescription, CardContent } from "@/components/ui/card";
+import { EmptyState } from "@/components/ui/EmptyState";
+import { Skeleton } from "@/components/ui/Skeleton";
+import { useInvestments } from "@/hooks/useInvestments";
 
 const BRL = (v: number) =>
   v.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -1,18 +1,19 @@
 // src/pages/Investments.tsx  (RESUMO)
 import { useEffect, useMemo, useState } from "react";
-import { supabase } from "@/lib/supabaseClient";
-import { useAuth } from "@/contexts/AuthContext";
-import PageHeader from "@/components/PageHeader";
 
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Input } from "@/components/ui/input";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-
+import { PieChart as PieIcon } from "lucide-react";
 import {
   ResponsiveContainer, PieChart, Pie, Cell, Legend,
   BarChart, Bar, CartesianGrid, XAxis, YAxis, Tooltip,
 } from "recharts";
-import { PieChart as PieIcon } from "lucide-react";
+
+import PageHeader from "@/components/PageHeader";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useAuth } from "@/contexts/AuthContext";
+import { supabase } from "@/lib/supabaseClient";
+
 
 /* ---------------- utils ---------------- */
 type Investment = {

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+
 import { useAuth } from '@/contexts/AuthContext';
 
 export default function Login() {

--- a/src/pages/Metas.tsx
+++ b/src/pages/Metas.tsx
@@ -1,46 +1,5 @@
 // src/pages/Metas.tsx
 import { useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
-import { supabase } from "@/lib/supabaseClient";
-import { useAuth } from "@/contexts/AuthContext";
-
-import PageHeader from "@/components/PageHeader";
-
-import {
-  Card,
-  CardHeader,
-  CardContent,
-  CardFooter,
-  CardTitle,
-  CardDescription,
-} from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
-import { Progress } from "@/components/ui/progress";
-import {
-  Dialog,
-  DialogContent,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectTrigger,
-  SelectValue,
-  SelectContent,
-  SelectItem,
-} from "@/components/ui/select";
-import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
 
 import {
   Plus,
@@ -57,6 +16,48 @@ import {
   Clock,
   Search,
 } from "lucide-react";
+import { toast } from "sonner";
+
+
+import PageHeader from "@/components/PageHeader";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  CardFooter,
+  CardTitle,
+  CardDescription,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Progress } from "@/components/ui/progress";
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { useAuth } from "@/contexts/AuthContext";
+import { supabase } from "@/lib/supabaseClient";
+
 
 /* ----------------------------- Tipos ----------------------------- */
 type GoalRow = {

--- a/src/pages/MilhasHome.tsx
+++ b/src/pages/MilhasHome.tsx
@@ -1,5 +1,5 @@
-import { Link } from 'react-router-dom';
 import { Plane } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 import PageHeader from '@/components/PageHeader';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';

--- a/src/pages/MilhasLivelo.tsx
+++ b/src/pages/MilhasLivelo.tsx
@@ -1,14 +1,15 @@
 import { useMemo, useState } from 'react';
+
 import dayjs from 'dayjs';
 import 'dayjs/locale/pt-br';
-import { toast } from 'sonner';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
+import { toast } from 'sonner';
 
 import MilesHeader, { type MilesProgram } from '@/components/MilesHeader';
-import { MotionCard } from '@/components/ui/MotionCard';
+import ModalMilesMovement, { type MilesMovement } from '@/components/ModalMilesMovement';
 import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
 import { Button } from '@/components/ui/button';
-import ModalMilesMovement, { type MilesMovement } from '@/components/ModalMilesMovement';
+import { MotionCard } from '@/components/ui/MotionCard';
 
 dayjs.locale('pt-br');
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,6 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
 import { fileURLToPath, URL } from 'node:url'
+
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
 
 // https://vite.dev/config/
 export default defineConfig({


### PR DESCRIPTION
## Summary
- configure ESLint to order imports by group and alphabetically
- add TypeScript resolver for eslint-plugin-import
- install eslint-import-resolver-typescript and sort imports across the project

## Testing
- `npx eslint .`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689cbc016bd4832298f00d545e6ccea2