### PR TITLE
fix: normalize import order spacing

### DIFF
--- a/src/pages/FinancasMensal.tsx
+++ b/src/pages/FinancasMensal.tsx
@@ -1,4 +1,5 @@
 // src/pages/FinancasMensal.tsx
+
 import { useEffect, useMemo, useState } from 'react';
 
 import dayjs from 'dayjs';


### PR DESCRIPTION
## Summary
- ensure finance monthly page imports have correct spacing between groups

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689cbff494a08322a0abcc68d81a7add