### PR TITLE
feat(auth): improve Supabase email flows

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,6 +30,7 @@ const ListaCompras = lazy(() => import('./pages/ListaCompras'));
 
 const Configuracoes = lazy(() => import('./pages/Configuracoes'));
 const Login         = lazy(() => import('./pages/Login'));
+const Confirm       = lazy(() => import('./pages/Confirm'));
 const ResetPassword = lazy(() => import('./pages/ResetPassword'));
 
 /* ────────────────────────────────────────────── */
@@ -55,7 +56,8 @@ function AppRoutes() {
     return (
       <Suspense fallback={<RouteLoader />}>
         <Routes>
-          {/* rota para redefinição de senha via e-mail do Supabase */}
+          {/* rotas públicas para e-mails do Supabase */}
+          <Route path="/confirm" element={<Confirm />} />
           <Route path="/reset-password" element={<ResetPassword />} />
           {/* rota explícita de login */}
           <Route path="/login" element={<Login />} />

--- a/src/pages/Confirm.tsx
+++ b/src/pages/Confirm.tsx
@@ -1,33 +1,52 @@
-// src/pages/Confirm.tsx
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
 
-import { supabase } from '@/lib/supabaseClient';
+import { supabase } from "@/lib/supabaseClient";
 
 export default function Confirm() {
+  const [state, setState] = useState<"loading" | "ok" | "error">("loading");
   const navigate = useNavigate();
 
   useEffect(() => {
     (async () => {
       try {
-        // o link pode vir como #access_token=... OU ?code=...
-        const payload = window.location.hash || window.location.search;
-        if (payload) {
-          await supabase.auth.exchangeCodeForSession(payload);
-        }
-        toast.success('E-mail confirmado! 👌');
-        navigate('/', { replace: true });
-      } catch (err: any) {
-        toast.error(err?.message ?? 'Falha ao confirmar e-mail');
-        navigate('/login', { replace: true });
+        // Lê os tokens do hash da URL e salva a sessão no storage
+        const { error } = await supabase.auth.getSessionFromUrl({ storeSession: true });
+        if (error) throw error;
+        setState("ok");
+        toast.success("E-mail confirmado! Faça login.");
+        setTimeout(() => navigate("/login", { replace: true }), 800);
+      } catch (err) {
+        console.error(err);
+        setState("error");
+        toast.error("Não foi possível confirmar seu e-mail. Tente novamente.");
       }
     })();
   }, [navigate]);
 
   return (
-    <div className="grid min-h-screen place-items-center text-emerald-900">
-      Processando confirmação…
+    <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-emerald-100 flex items-center justify-center p-4">
+      <div className="w-full max-w-md rounded-2xl bg-white/70 backdrop-blur shadow-xl border border-emerald-100 p-6">
+        <div className="flex items-center gap-3 mb-2">
+          <div className="h-10 w-10 rounded-full bg-emerald-600 text-white grid place-items-center font-bold">FY</div>
+          <h1 className="text-xl font-semibold text-emerald-900">Confirmando seu e-mail…</h1>
+        </div>
+        {state === "loading" && <p className="text-emerald-700">Preparando sessão segura…</p>}
+        {state === "ok" && <p className="text-emerald-700">Tudo certo! Redirecionando…</p>}
+        {state === "error" && (
+          <div className="space-y-3">
+            <p className="text-red-700">Link inválido ou expirado.</p>
+            <button
+              onClick={() => navigate("/login")}
+              className="w-full h-10 rounded-lg bg-emerald-600 text-white font-medium hover:bg-emerald-700 transition"
+            >
+              Voltar para o login
+            </button>
+          </div>
+        )}
+      </div>
     </div>
   );
 }
+

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,175 +1,116 @@
-// src/pages/ResetPassword.tsx
-import { useEffect, useMemo, useState } from 'react';
-import { useLocation, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { toast } from "sonner";
 
-import { supabase } from '@/lib/supabaseClient';
-
-function extractTokens(url: string) {
-  // Suporta formatos do Supabase:
-  // 1) /reset-password#access_token=...&refresh_token=...&type=recovery
-  // 2) /reset-password?access_token=...&refresh_token=...&type=recovery
-  // 3) /reset-password?code=...&type=recovery (PKCE / exchangeCodeForSession)
-  const u = new URL(url);
-
-  const hashParams = new URLSearchParams(u.hash.startsWith('#') ? u.hash.slice(1) : u.hash);
-  const queryParams = new URLSearchParams(u.search);
-
-  const access_token =
-    hashParams.get('access_token') || queryParams.get('access_token') || undefined;
-  const refresh_token =
-    hashParams.get('refresh_token') || queryParams.get('refresh_token') || undefined;
-  const code = hashParams.get('code') || queryParams.get('code') || undefined;
-  const type = hashParams.get('type') || queryParams.get('type') || undefined;
-
-  return { access_token, refresh_token, code, type };
-}
+import { supabase } from "@/lib/supabaseClient";
 
 export default function ResetPassword() {
-  const location = useLocation();
+  const [phase, setPhase] = useState<"preparing" | "form" | "saving">("preparing");
+  const [password, setPassword] = useState("");
+  const [confirm, setConfirm] = useState("");
   const navigate = useNavigate();
 
-  const { access_token, refresh_token, code, type } = useMemo(
-    () => extractTokens(window.location.href),
-    [location.search, location.hash]
-  );
-
-  const [ready, setReady] = useState(false);
-  const [busy, setBusy] = useState(false);
-  const [pwd, setPwd] = useState('');
-  const [pwd2, setPwd2] = useState('');
-
-  // 1) Assim que chegar, setSession com os tokens do link de recuperação
+  // 1) Quando chega do e-mail, o Supabase manda tokens no hash.
+  // Precisamos ler e armazenar a sessão antes de permitir trocar a senha.
   useEffect(() => {
     (async () => {
       try {
-        // Prioridade: fluxo com "code" (PKCE, recomendado nas versões recentes do supabase-js)
-        if (code) {
-          const { error } = await supabase.auth.exchangeCodeForSession(code);
-          if (error) {
-            toast.error(error.message || 'Não foi possível validar o link de recuperação.');
-            return;
-          }
-          // sessão disponível; seguimos para permitir updateUser
-          setReady(true);
-          return;
-        }
-
-        // Fallback para links antigos com access/refresh tokens
-        if (access_token && refresh_token) {
-          const { error } = await supabase.auth.setSession({ access_token, refresh_token });
-          if (error) {
-            toast.error(error.message || 'Não foi possível iniciar a sessão de recuperação.');
-            return;
-          }
-          setReady(true);
-          return;
-        }
-
-        // Nenhum formato reconhecido
-        toast.error('Link inválido ou expirado. Refaça o pedido de redefinição.');
-      } catch (e: any) {
-        toast.error(e?.message ?? 'Falha ao preparar redefinição.');
+        const { error } = await supabase.auth.getSessionFromUrl({ storeSession: true });
+        if (error) throw error;
+        setPhase("form");
+      } catch (err) {
+        console.error(err);
+        toast.error("Link inválido ou expirado.");
+        navigate("/login", { replace: true });
       }
     })();
-  }, [access_token, refresh_token, code, type]);
+  }, [navigate]);
 
   async function onSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!ready) return;
-
-    if (pwd.length < 6) {
-      toast.error('A senha precisa ter pelo menos 6 caracteres.');
+    if (password.length < 6) {
+      toast.error("A senha precisa ter ao menos 6 caracteres.");
       return;
     }
-    if (pwd !== pwd2) {
-      toast.error('As senhas não conferem.');
+    if (password !== confirm) {
+      toast.error("As senhas não conferem.");
       return;
     }
 
-    setBusy(true);
-    try {
-      const { error } = await supabase.auth.updateUser({ password: pwd });
-      if (error) {
-        toast.error(error.message || 'Não foi possível salvar a nova senha.');
-        return;
-      }
-
-      toast.success('Senha atualizada! Faça login novamente.');
-      // Garante que a sessão "de recuperação" não persista
-      await supabase.auth.signOut();
-      // Limpa hash/query e redireciona
-      navigate('/login', { replace: true, state: { resetSuccess: true } });
-    } catch (e: any) {
-      toast.error(e?.message ?? 'Erro inesperado ao salvar a senha.');
-    } finally {
-      setBusy(false);
+    setPhase("saving");
+    const { error } = await supabase.auth.updateUser({ password });
+    if (error) {
+      console.error(error);
+      toast.error("Não foi possível salvar sua nova senha.");
+      setPhase("form");
+      return;
     }
+
+    toast.success("Senha alterada! Faça login novamente.");
+    await supabase.auth.signOut();
+    navigate("/login", { replace: true });
+  }
+
+  if (phase === "preparing") {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-emerald-100 grid place-items-center p-4">
+        <div className="w-full max-w-md rounded-2xl bg-white/70 backdrop-blur shadow-xl border border-emerald-100 p-6">
+          <div className="flex items-center gap-3 mb-2">
+            <div className="h-10 w-10 rounded-full bg-emerald-600 text-white grid place-items-center font-bold">FY</div>
+            <h1 className="text-xl font-semibold text-emerald-900">Definir nova senha</h1>
+          </div>
+          <p className="text-emerald-700">Preparando a sessão segura para redefinir sua senha…</p>
+        </div>
+      </div>
+    );
   }
 
   return (
-    <div className="relative min-h-screen overflow-hidden">
-      {/* fundo esmeralda */}
-      <div className="absolute inset-0 bg-gradient-to-b from-emerald-50 via-white to-emerald-50" />
-      <div className="pointer-events-none absolute -top-24 -left-24 h-72 w-72 rounded-full bg-emerald-300 blur-3xl opacity-30 animate-pulse" />
-      <div className="pointer-events-none absolute -bottom-20 -right-20 h-80 w-80 rounded-full bg-emerald-400 blur-3xl opacity-20 animate-[pulse_3s_ease-in-out_infinite]" />
+    <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-emerald-100 grid place-items-center p-4">
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-md rounded-2xl bg-white/70 backdrop-blur shadow-xl border border-emerald-100 p-6 space-y-4"
+      >
+        <div className="flex items-center gap-3">
+          <div className="h-10 w-10 rounded-full bg-emerald-600 text-white grid place-items-center font-bold">FY</div>
+          <h1 className="text-xl font-semibold text-emerald-900">Definir nova senha</h1>
+        </div>
 
-      <div className="relative grid min-h-screen place-items-center p-4">
-        <form
-          onSubmit={onSubmit}
-          className="w-full max-w-md rounded-3xl border border-emerald-900/5 bg-white/70 backdrop-blur-xl p-6 shadow-xl"
+        <div>
+          <label className="block text-sm font-medium text-emerald-900 mb-1">Nova senha</label>
+          <input
+            type="password"
+            className="w-full h-10 rounded-lg border border-emerald-200 bg-white/80 px-3 outline-none focus:ring-2 focus:ring-emerald-400"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            autoComplete="new-password"
+            required
+            minLength={6}
+          />
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-emerald-900 mb-1">Confirmar senha</label>
+          <input
+            type="password"
+            className="w-full h-10 rounded-lg border border-emerald-200 bg-white/80 px-3 outline-none focus:ring-2 focus:ring-emerald-400"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            autoComplete="new-password"
+            required
+            minLength={6}
+          />
+        </div>
+
+        <button
+          type="submit"
+          disabled={phase === "saving"}
+          className="w-full h-10 rounded-lg bg-emerald-600 text-white font-medium hover:bg-emerald-700 disabled:opacity-60 transition"
         >
-          <div className="flex items-center gap-3 mb-2">
-            <div className="size-11 rounded-full bg-emerald-600 text-white grid place-items-center shadow-lg">
-              <span className="font-bold">FY</span>
-            </div>
-            <div>
-              <h1 className="text-xl font-semibold text-emerald-900">Definir nova senha</h1>
-              <p className="text-sm text-emerald-800/70">Informe sua nova senha abaixo.</p>
-            </div>
-          </div>
-
-          {!ready ? (
-            <p className="mt-4 text-sm text-emerald-900/70">
-              Preparando a sessão segura para redefinir sua senha…
-            </p>
-          ) : (
-            <>
-              <label className="mt-4 block text-sm font-medium text-emerald-900">
-                Nova senha
-              </label>
-              <input
-                type="password"
-                className="mt-1 w-full rounded-xl border border-emerald-900/10 bg-white px-3 py-2 outline-none ring-emerald-500/20 focus:ring-2"
-                value={pwd}
-                onChange={(e) => setPwd(e.target.value)}
-                minLength={6}
-                required
-              />
-
-              <label className="mt-4 block text-sm font-medium text-emerald-900">
-                Confirmar senha
-              </label>
-              <input
-                type="password"
-                className="mt-1 w-full rounded-xl border border-emerald-900/10 bg-white px-3 py-2 outline-none ring-emerald-500/20 focus:ring-2"
-                value={pwd2}
-                onChange={(e) => setPwd2(e.target.value)}
-                minLength={6}
-                required
-              />
-
-              <button
-                type="submit"
-                disabled={busy || !ready}
-                className="mt-6 w-full rounded-xl bg-emerald-600 py-2.5 font-medium text-white shadow-sm transition hover:bg-emerald-700 disabled:opacity-60"
-              >
-                {busy ? 'Salvando…' : 'Salvar nova senha'}
-              </button>
-            </>
-          )}
-        </form>
-      </div>
+          {phase === "saving" ? "Salvando…" : "Salvar nova senha"}
+        </button>
+      </form>
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- add confirmation page that stores Supabase session and redirects to login
- allow password reset after validating Supabase URL tokens
- wire new confirm and reset-password routes in App

## Testing
- `npm run lint`
- `npm run dev`
- `curl -I http://localhost:5173/confirm`
- `curl -I http://localhost:5173/reset-password`


------
https://chatgpt.com/codex/tasks/task_e_689d34b451648322985785c9fc16b663