### PR TITLE
feat: wrap app with period provider

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import AppHotkeys from '@/components/AppHotkeys';
 import RouteLoader from '@/components/RouteLoader';
 import Sidebar from '@/components/Sidebar';
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
+import { PeriodProvider } from '@/contexts/PeriodContext';
 /* ---------- lazy imports de páginas ---------- */
 const Dashboard      = lazy(() => import('./pages/Dashboard'));
 const FinancasMensal = lazy(() => import('./pages/FinancasMensal'));
@@ -39,11 +40,13 @@ const ResetPassword = lazy(() => import('./pages/ResetPassword'));
 export default function App() {
   return (
     <AuthProvider>
-      <Router>
-        {/* Toaster global */}
-        <Toaster richColors position="top-right" />
-        <AppRoutes />
-      </Router>
+      <PeriodProvider>
+        <Router>
+          {/* Toaster global */}
+          <Toaster richColors position="top-right" />
+          <AppRoutes />
+        </Router>
+      </PeriodProvider>
     </AuthProvider>
   );
 }

--- a/src/pages/FinancasMensal.tsx
+++ b/src/pages/FinancasMensal.tsx
@@ -6,7 +6,7 @@ import { toast } from 'sonner';
 
 import CategoryDonut from '@/components/charts/CategoryDonut';
 import DailyBars from '@/components/charts/DailyBars';
-import { ModalTransacao } from '@/components/ModalTransacao';
+import { ModalTransacao, type BaseData } from '@/components/ModalTransacao';
 import PageHeader from '@/components/PageHeader';
 import SourcePicker, { type SourceValue } from '@/components/SourcePicker';
 import CategoryPicker from '@/components/CategoryPicker';
@@ -26,8 +26,6 @@ import { useTransactions, type Transaction, type TransactionInput } from '@/hook
 import 'dayjs/locale/pt-br';
 dayjs.locale('pt-br');
 
-// Shims rápidos para compilar. Depois podemos trocar pelos tipos reais.
-type BaseData = Record<string, any>;
 
 // utils simples p/ busca sem acento
 const norm = (s: string) =>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -45,7 +45,6 @@ export default function Login() {
     const el = pwdRef.current;
     if (!el) return;
     const handle = (e: KeyboardEvent) => {
-      // @ts-expect-error Chrome
       const isCaps = e.getModifierState?.('CapsLock');
       setCapsOn(!!isCaps);
     };


### PR DESCRIPTION
## Summary
- wrap router with `PeriodProvider` to supply period context to all pages
- align types in `FinancasMensal` and clean up unused directive in `Login`

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689d43f685588322b4897cd3a8b95aa1