### PR TITLE
Avoid empty string values in Select components

### DIFF
--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -111,6 +111,7 @@ export default function FilterBar({ variant = "default", className = "" }: Props
           <span className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10">
             <CalendarRange className="h-4 w-4 text-emerald-600" />
           </span>
+          {/* Nunca usar "" como value controlado */}
           <Select value={String(month)} onValueChange={(v) => setMonth(Number(v))}>
             <SelectTrigger className="w-[120px] rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10">
               <SelectValue placeholder="Mês" />
@@ -131,6 +132,7 @@ export default function FilterBar({ variant = "default", className = "" }: Props
         <span className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10">
           <Calendar className="h-4 w-4 text-emerald-600" />
         </span>
+        {/* Nunca passe "" como value */}
         <Select value={String(year)} onValueChange={(v) => setYear(Number(v))}>
           <SelectTrigger className="w-[110px] rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10">
             <SelectValue placeholder="Ano" />

--- a/src/components/SourcePicker.tsx
+++ b/src/components/SourcePicker.tsx
@@ -98,8 +98,11 @@ export default function SourcePicker({
       {/* Picker por tipo */}
       {kind === "account" ? (
         <Select
-          value={selectedId ?? ""}
-          onValueChange={(v) => onChange({ kind: "account", id: v || null })}
+          // Nunca passe "" para value. Use undefined para indicar falta de seleção.
+          value={selectedId ?? undefined}
+          onValueChange={(v) =>
+            onChange({ kind: "account", id: !v || v === "Todas" ? null : v })
+          }
         >
           <SelectTrigger
             aria-label={ariaLabel ?? placeholder}
@@ -108,8 +111,10 @@ export default function SourcePicker({
             <SelectValue placeholder={placeholder} />
           </SelectTrigger>
           <SelectContent className="rounded-xl max-h-72">
-            <SelectItem value="">Todas</SelectItem>
+            {/* Token explícito para "todas" evita value="" */}
+            <SelectItem value="Todas">Todas</SelectItem>
             {accounts.map((a) => (
+              // Garanta que value nunca seja string vazia
               <SelectItem key={a.id} value={a.id}>
                 <span className="inline-flex items-center gap-2">
                   <span className="h-2.5 w-2.5 rounded-full bg-emerald-500" />
@@ -125,8 +130,10 @@ export default function SourcePicker({
       ) : (
         <>
           <Select
-            value={selectedId ?? ""}
-            onValueChange={(v) => onChange({ kind: "card", id: v || null })}
+            value={selectedId ?? undefined}
+            onValueChange={(v) =>
+              onChange({ kind: "card", id: !v || v === "Todas" ? null : v })
+            }
           >
           <SelectTrigger
             aria-label={ariaLabel ?? placeholder}
@@ -135,7 +142,7 @@ export default function SourcePicker({
             <SelectValue placeholder={placeholder} />
           </SelectTrigger>
           <SelectContent className="rounded-xl max-h-72">
-            <SelectItem value="">Todas</SelectItem>
+            <SelectItem value="Todas">Todas</SelectItem>
             {cards.map((c) => (
               <SelectItem key={c.id} value={c.id}>
                   <span className="inline-flex items-center gap-2">


### PR DESCRIPTION
## Summary
- prevent empty string values in source selector by using explicit `"Todas"` token and normalizing on change
- document that month and year filters should never use empty string values

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d49ec608883229ceeb4f0d5682508