### PR TITLE
evita value vazio em SelectItem e adiciona codemod

### DIFF
--- a/scripts/codemod-fix-empty-select-items.mjs
+++ b/scripts/codemod-fix-empty-select-items.mjs
@@ -1,0 +1,49 @@
+import fs from "node:fs";
+import path from "node:path";
+
+const root = path.resolve(process.cwd(), "src");
+const exts = new Set([".tsx", ".ts", ".jsx", ".js"]);
+
+/** Varre todos os arquivos do src e aplica correções simples: 
+ *  - <SelectItem value=""> -> <SelectItem value="Todas">
+ *  - value={(algo ?? "")}  -> value={String(algo ?? "TokenSemVazio")}
+ *  - value={""}            -> value={"TokenSemVazio"}
+ */
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const p = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(p);
+    else if (exts.has(path.extname(entry.name))) fixFile(p);
+  }
+}
+
+function fixFile(file) {
+  let src = fs.readFileSync(file, "utf8");
+  const before = src;
+
+  // 1) <SelectItem value="">
+  src = src.replace(
+    /<\s*SelectItem([^>]*?)value\s*=\s*""/g,
+    (_m, attrs) => `<SelectItem${attrs}value="Todas"`
+  );
+
+  // 2) value={(algo ?? "")}
+  src = src.replace(
+    /value=\{\s*([^}]+?)\s*\?\?\s*""\s*\}/g,
+    (_m, inner) => `value={String(${inner} ?? "TokenSemVazio")}`
+  );
+
+  // 3) value={""}
+  src = src.replace(
+    /value=\{\s*""\s*\}/g,
+    'value={"TokenSemVazio"}'
+  );
+
+  if (src !== before) {
+    fs.writeFileSync(file, src);
+    console.log("✔ Corrigido:", file);
+  }
+}
+
+walk(root);
+console.log("Done.");

--- a/src/components/CategoryPicker.tsx
+++ b/src/components/CategoryPicker.tsx
@@ -271,7 +271,7 @@ export default function CategoryPicker({
                 <Input
                   id={colorHexId}
                   aria-label="Código da cor"
-                  value={color ?? ""}
+                  value={String(color ?? "TokenSemVazio")}
                   onChange={(e) => setColor(e.target.value)}
                   placeholder="#RRGGBB"
                   className="font-mono"

--- a/src/components/ModalCartao.tsx
+++ b/src/components/ModalCartao.tsx
@@ -131,7 +131,7 @@ export default function ModalCartao({ open, onClose, onCreated }: ModalCartaoPro
                   {accounts.map((a) => (
                     <SelectItem key={a.id} value={a.id}>{a.name}</SelectItem>
                   ))}
-                  <SelectItem value="">(Nenhuma)</SelectItem>
+                  <SelectItem value="Todas">(Nenhuma)</SelectItem>
                 </SelectContent>
               </Select>
             </div>

--- a/src/components/ModalInvest.tsx
+++ b/src/components/ModalInvest.tsx
@@ -191,7 +191,7 @@ export default function ModalInvest({ open, onClose, initial, defaultType, onSub
             <div className="grid gap-1.5">
               <Label>Ticker/Símbolo (opcional)</Label>
               <Input
-                value={f.symbol ?? ""}
+                value={String(f.symbol ?? "TokenSemVazio")}
                 onChange={(e) => set("symbol", e.target.value)}
                 placeholder="MXRF11, PETR4, BTC…"
               />
@@ -231,7 +231,7 @@ export default function ModalInvest({ open, onClose, initial, defaultType, onSub
             </div>
             <div className="grid gap-1.5">
               <Label>Corretora (opcional)</Label>
-              <Input value={f.broker ?? ""} onChange={(e) => set("broker", e.target.value)} />
+              <Input value={String(f.broker ?? "TokenSemVazio")} onChange={(e) => set("broker", e.target.value)} />
             </div>
             <div className="grid gap-1.5">
               <Label>Data</Label>
@@ -242,7 +242,7 @@ export default function ModalInvest({ open, onClose, initial, defaultType, onSub
           <div className="grid gap-1.5">
             <Label>Observação (opcional)</Label>
             <Input
-              value={f.note ?? ""}
+              value={String(f.note ?? "TokenSemVazio")}
               onChange={(e) => set("note", e.target.value)}
               placeholder="Ex.: aporte mensal, compra fracionada…"
             />

--- a/src/pages/Metas.tsx
+++ b/src/pages/Metas.tsx
@@ -613,7 +613,7 @@ export default function Metas() {
                   type="number"
                   inputMode="decimal"
                   placeholder="opcional"
-                  value={goalForm.expected_rate ?? ""}
+                  value={String(goalForm.expected_rate ?? "TokenSemVazio")}
                   onChange={(e) =>
                     setGoalForm((s) => ({
                       ...s,


### PR DESCRIPTION
## Summary
- adiciona script de codemod para evitar `value=""` em SelectItem e padrões com `?? ""`
- ajusta CategoryPicker, ModalCartao, ModalInvest e Metas para remover strings vazias

## Testing
- `npm run lint`
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_689d4d146ad08322840e79f16f3525b4