### PR TITLE
feat: add home overview dashboard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,10 @@ import Sidebar from '@/components/Sidebar';
 import { AuthProvider, useAuth } from '@/contexts/AuthContext';
 import { PeriodProvider } from '@/contexts/PeriodContext';
 /* ---------- lazy imports de páginas ---------- */
-const Dashboard      = lazy(() => import('./pages/Dashboard'));
+// Renomeamos o antigo "Dashboard" (focado em finanças) para FinancasResumo
+const FinancasResumo = lazy(() => import('./pages/FinancasResumo'));
+// Novo dashboard geral com cartões-resumo de módulos (finanças, investimentos, metas, milhas, listas)
+const Dashboard      = lazy(() => import('./pages/HomeOverview'));
 const FinancasMensal = lazy(() => import('./pages/FinancasMensal'));
 const FinancasAnual  = lazy(() => import('./pages/FinancasAnual'));
 
@@ -23,6 +26,7 @@ const CarteiraCripto    = lazy(() => import('./pages/CarteiraCripto'));
 
 const Metas = lazy(() => import('./pages/Metas'));
 
+const MilhasHome   = lazy(() => import('./pages/MilhasHome'));
 const MilhasLivelo = lazy(() => import('./pages/MilhasLivelo'));
 const MilhasLatam  = lazy(() => import('./pages/MilhasLatam'));
 const MilhasAzul   = lazy(() => import('./pages/MilhasAzul'));
@@ -81,13 +85,12 @@ function AppRoutes() {
         <Suspense fallback={<RouteLoader />}>
 
           <Routes>
-            {/* redirect raiz */}
-            <Route path="/" element={<Navigate to="/dashboard" />} />
-
             {/* Dashboard */}
             <Route path="/dashboard" element={<Dashboard />} />
+            <Route path="/" element={<Dashboard />} />
 
             {/* Finanças */}
+            <Route path="/financas/resumo" element={<FinancasResumo />} />
             <Route path="/financas/mensal" element={<FinancasMensal />} />
             <Route path="/financas/anual"  element={<FinancasAnual />} />
 
@@ -104,6 +107,7 @@ function AppRoutes() {
             <Route path="/metas" element={<Metas />} />
 
             {/* Milhas */}
+            <Route path="/milhas"           element={<MilhasHome />} />
             <Route path="/milhas/livelo"    element={<MilhasLivelo />} />
             <Route path="/milhas/latampass" element={<MilhasLatam />} />
             <Route path="/milhas/azul"      element={<MilhasAzul />} />

--- a/src/components/AppHotkeys.tsx
+++ b/src/components/AppHotkeys.tsx
@@ -25,7 +25,7 @@ export function AppHotkeys() {
         e.preventDefault();
         toast.message("Atalhos", {
           description:
-            "N: nova transação • /: buscar • F: Finanças • M: Milhas • g d: Dashboard • g f: Finanças • g i: Investimentos • g m: Metas • g c: Configurações",
+            "N: nova transação • /: buscar • F: Finanças • M: Milhas • g d: Visão geral • g f: Finanças • g i: Investimentos • g m: Metas • g c: Configurações",
         });
         return;
       }

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,10 +18,11 @@ const sections: Section[] = [
   {
     label: "Geral",
     items: [
-      { type: "item", label: "Dashboard", to: "/dashboard", icon: LayoutDashboard },
+      { type: "item", label: "Visão geral", to: "/dashboard", icon: LayoutDashboard },
       {
         type: "group", label: "Finanças", icon: Wallet,
         children: [
+          { type: "item", label: "Resumo", to: "/financas/resumo", icon: LayoutDashboard },
           { type: "item", label: "Mensal", to: "/financas/mensal", icon: CalendarRange },
           { type: "item", label: "Anual", to: "/financas/anual", icon: CalendarRange },
         ],

--- a/src/pages/FinancasResumo.tsx
+++ b/src/pages/FinancasResumo.tsx
@@ -1,0 +1,2 @@
+// Wrapper que reaproveita o conteúdo antigo de Dashboard.tsx (finanças)
+export { default } from "./Dashboard";

--- a/src/pages/HomeOverview.tsx
+++ b/src/pages/HomeOverview.tsx
@@ -1,0 +1,72 @@
+import { Link } from "react-router-dom";
+import { TrendingUp, Wallet, Target, Plane, Heart, ShoppingCart } from "lucide-react";
+
+import PageHeader from "@/components/PageHeader";
+import { Card } from "@/components/ui/card";
+
+export default function HomeOverview() {
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Visão geral"
+        subtitle="Resumo rápido de finanças, investimentos, metas e mais."
+      />
+      <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
+        <Link to="/financas/resumo" className="block">
+          <Card className="p-6 flex items-center gap-4">
+            <TrendingUp className="h-6 w-6" />
+            <div>
+              <div className="font-semibold">Finanças</div>
+              <div className="text-sm text-muted-foreground">Resumo mensal e anual</div>
+            </div>
+          </Card>
+        </Link>
+        <Link to="/investimentos" className="block">
+          <Card className="p-6 flex items-center gap-4">
+            <Wallet className="h-6 w-6" />
+            <div>
+              <div className="font-semibold">Investimentos</div>
+              <div className="text-sm text-muted-foreground">Resumo e carteira</div>
+            </div>
+          </Card>
+        </Link>
+        <Link to="/metas" className="block">
+          <Card className="p-6 flex items-center gap-4">
+            <Target className="h-6 w-6" />
+            <div>
+              <div className="font-semibold">Metas & Projetos</div>
+              <div className="text-sm text-muted-foreground">Progresso e aportes</div>
+            </div>
+          </Card>
+        </Link>
+        <Link to="/milhas" className="block">
+          <Card className="p-6 flex items-center gap-4">
+            <Plane className="h-6 w-6" />
+            <div>
+              <div className="font-semibold">Milhas</div>
+              <div className="text-sm text-muted-foreground">Saldo, a receber e expiração</div>
+            </div>
+          </Card>
+        </Link>
+        <Link to="/lista-desejos" className="block">
+          <Card className="p-6 flex items-center gap-4">
+            <Heart className="h-6 w-6" />
+            <div>
+              <div className="font-semibold">Lista de desejos</div>
+              <div className="text-sm text-muted-foreground">Planejamento de compras</div>
+            </div>
+          </Card>
+        </Link>
+        <Link to="/lista-compras" className="block">
+          <Card className="p-6 flex items-center gap-4">
+            <ShoppingCart className="h-6 w-6" />
+            <div>
+              <div className="font-semibold">Lista de compras</div>
+              <div className="text-sm text-muted-foreground">Itens e orçamentos</div>
+            </div>
+          </Card>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/MilhasHome.tsx
+++ b/src/pages/MilhasHome.tsx
@@ -55,7 +55,7 @@ export default function MilhasHome() {
             </CardHeader>
           </Card>
         </Link>
-        <Link to="/milhas/latam" className="block">
+        <Link to="/milhas/latampass" className="block">
           <Card className="hover:bg-muted/50">
             <CardHeader className="text-center">
               <CardTitle>LATAM Pass</CardTitle>


### PR DESCRIPTION
## Summary
- add new home overview dashboard with quick links to modules
- rename old dashboard to "Finanças Resumo" and adjust routes
- update sidebar and hotkey help to reflect new navigation
- fix LATAM Pass link and add base milhas route

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d52d79dec8322b506e537b2d99b3c