### PR TITLE
fix: remove ghost CTA overlay from KPI cards

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -557,8 +557,9 @@ function KpiCard({
       transition={{ type: "spring", stiffness: 220, damping: 18 }}
       className="kpi relative h-[136px]"
     >
+      {/* Ícone decorativo sem capturar cliques */}
       <div
-        className="absolute -right-8 -top-8 h-28 w-28 rounded-full opacity-30 blur-2xl"
+        className="pointer-events-none absolute -right-8 -top-8 h-28 w-28 rounded-full opacity-20 blur-2xl"
         style={{ background: `linear-gradient(135deg, ${colorFrom}, ${colorTo})` }}
       />
       <div className="flex items-start justify-between gap-3">


### PR DESCRIPTION
## Summary
- prevent decorative KPI backdrop from intercepting clicks by disabling pointer events

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d52fae6b8832292f26266cbfc754d