### PR TITLE
feat: add program-specific mile headers

### DIFF
--- a/src/assets/logos/azul.svg
+++ b/src/assets/logos/azul.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="20" fill="#0075C9"/>
+  <text x="50" y="55" font-size="40" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif">Azul</text>
+</svg>

--- a/src/assets/logos/latampass.svg
+++ b/src/assets/logos/latampass.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="20" fill="#C8102E"/>
+  <text x="50" y="55" font-size="40" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif">LATAM</text>
+</svg>

--- a/src/assets/logos/livelo.svg
+++ b/src/assets/logos/livelo.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect width="100" height="100" rx="20" fill="#EA1E79"/>
+  <text x="50" y="55" font-size="50" text-anchor="middle" fill="#fff" font-family="Arial, sans-serif">L</text>
+</svg>

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,20 +1,37 @@
 // src/components/PageHeader.tsx
 import type { ReactNode } from "react";
 
+import { cn } from "@/lib/utils";
+
 export type Breadcrumb = { label: string; href?: string };
 
 export type PageHeaderProps = {
-  title: string; subtitle?: string; icon?: ReactNode;
-  actions?: ReactNode; breadcrumbs?: Breadcrumb[]; children?: ReactNode;
+  title: string;
+  subtitle?: string;
+  icon?: ReactNode;
+  actions?: ReactNode;
+  breadcrumbs?: Breadcrumb[];
+  children?: ReactNode;
+  gradient?: string;
+  logoSrc?: string;
 };
 
 const PageHeader = (props: PageHeaderProps) => {
-  const { title, subtitle, icon, actions, breadcrumbs, children } = props;
+  const { title, subtitle, icon, actions, breadcrumbs, children, gradient, logoSrc } = props;
   return (
-    <div className="mb-6 rounded-xl bg-gradient-to-r from-emerald-900 to-teal-700 text-white">
+    <div
+      className={cn(
+        "mb-6 rounded-xl text-white",
+        gradient ? `bg-gradient-to-r ${gradient}` : "bg-gradient-to-r from-emerald-900 to-teal-700"
+      )}
+    >
       <div className="container mx-auto px-4 py-5 flex items-center justify-between gap-4">
         <div className="flex items-center gap-3 min-w-0">
-          {icon ? <div className="rounded-lg bg-white/10 p-2 shrink-0">{icon}</div> : null}
+          {logoSrc ? (
+            <img src={logoSrc} alt="" className="h-8 w-8 shrink-0 rounded-md" />
+          ) : icon ? (
+            <div className="rounded-lg bg-white/10 p-2 shrink-0">{icon}</div>
+          ) : null}
           <div className="min-w-0">
             <h1 className="text-xl sm:text-2xl font-semibold truncate">{title}</h1>
             {subtitle ? (

--- a/src/pages/MilhasAzul.tsx
+++ b/src/pages/MilhasAzul.tsx
@@ -1,4 +1,5 @@
 import MilhasLivelo from './MilhasLivelo';
+
 export default function MilhasAzul() {
-  return <MilhasLivelo />;
+  return <MilhasLivelo program="azul" />;
 }

--- a/src/pages/MilhasLatam.tsx
+++ b/src/pages/MilhasLatam.tsx
@@ -1,7 +1,5 @@
 import MilhasLivelo from './MilhasLivelo';
+
 export default function MilhasLatam() {
-  // Reuso rápido: mesma página, trocando somente o título/badge
-  // Para personalizar (cores/regras), podemos separar depois.
-  // Como atalho, apenas exporto a versão reutilizada e você muda o título no PageHeader.
-  return <MilhasLivelo />;
+  return <MilhasLivelo program="latam" />;
 }

--- a/src/pages/MilhasLivelo.tsx
+++ b/src/pages/MilhasLivelo.tsx
@@ -3,16 +3,39 @@ import dayjs from 'dayjs';
 import { toast } from 'sonner';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
 
-import MilesHeader from '@/components/MilesHeader';
+import PageHeader from '@/components/PageHeader';
 import { MotionCard } from '@/components/ui/MotionCard';
 import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
 import { Button } from '@/components/ui/button';
 import ModalMilesMovement, { type MilesMovement } from '@/components/ModalMilesMovement';
+import liveloLogo from '@/assets/logos/livelo.svg';
+import latamLogo from '@/assets/logos/latampass.svg';
+import azulLogo from '@/assets/logos/azul.svg';
 
 import 'dayjs/locale/pt-br';
 dayjs.locale('pt-br');
 
-export default function MilhasLivelo() {
+type Program = 'livelo' | 'latam' | 'azul';
+
+const CONFIG: Record<Program, { title: string; gradient: string; logo: string }> = {
+  livelo: {
+    title: 'Milhas — Livelo',
+    gradient: 'from-fuchsia-600 via-pink-500 to-rose-500',
+    logo: liveloLogo,
+  },
+  latam: {
+    title: 'Milhas — LATAM Pass',
+    gradient: 'from-red-600 via-rose-600 to-purple-600',
+    logo: latamLogo,
+  },
+  azul: {
+    title: 'Milhas — Azul',
+    gradient: 'from-sky-600 via-cyan-600 to-blue-600',
+    logo: azulLogo,
+  },
+};
+
+export default function MilhasLivelo({ program = 'livelo' }: { program?: Program }) {
   const [open, setOpen] = useState(false);
   const [edit, setEdit] = useState<MilesMovement | null>(null);
 
@@ -61,11 +84,17 @@ export default function MilhasLivelo() {
     toast.success('Excluído');
   };
 
+  const cfg = CONFIG[program];
+
   return (
     <div className="space-y-6">
-      <MilesHeader program="livelo" subtitle="Saldo, expiração e movimentos">
-        <Button onClick={()=>{ setEdit(null); setOpen(true); }}>Novo movimento</Button>
-      </MilesHeader>
+      <PageHeader
+        title={cfg.title}
+        subtitle="Saldo, a receber e expiração"
+        gradient={cfg.gradient}
+        logoSrc={cfg.logo}
+        actions={<Button onClick={()=>{ setEdit(null); setOpen(true); }}>Novo movimento</Button>}
+      />
 
       {/* KPIs */}
       <section className="grid gap-4 sm:grid-cols-4">


### PR DESCRIPTION
## Summary
- add optional gradient and logo to PageHeader
- show program-specific header for miles pages and expose wrapper components
- include provisional SVG logos for Livelo, LATAM Pass, and Azul

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d53ac4a9c832296ccc30fa5e47f31