### PR TITLE
feat: add pending miles list

### DIFF
--- a/src/components/miles/MilesPendingList.tsx
+++ b/src/components/miles/MilesPendingList.tsx
@@ -1,0 +1,78 @@
+import dayjs from 'dayjs';
+import { useMemo } from 'react';
+
+import type { MilesProgram } from '@/components/MilesHeader';
+
+export type MilesPending = {
+  id: string;
+  program: MilesProgram;
+  partner: string;
+  points: number;
+  expected_at: string; // YYYY-MM-DD
+};
+
+// Dados mockados; integração futura com backend/Supabase
+const MOCK: MilesPending[] = [
+  {
+    id: '1',
+    program: 'livelo',
+    partner: 'Compra Loja X',
+    points: 500,
+    expected_at: dayjs().add(10, 'day').format('YYYY-MM-DD'),
+  },
+  {
+    id: '2',
+    program: 'latam',
+    partner: 'Cartão de crédito',
+    points: 1000,
+    expected_at: dayjs().add(30, 'day').format('YYYY-MM-DD'),
+  },
+  {
+    id: '3',
+    program: 'azul',
+    partner: 'Hotel',
+    points: 800,
+    expected_at: dayjs().add(20, 'day').format('YYYY-MM-DD'),
+  },
+];
+
+export default function MilesPendingList({ program }: { program?: MilesProgram }) {
+  const itens = useMemo(() => MOCK.filter((m) => !program || m.program === program), [program]);
+  const colSpan = program ? 3 : 4;
+
+  return (
+    <div className="rounded-xl border bg-white dark:bg-slate-900 p-4">
+      <h3 className="font-medium mb-3">A receber</h3>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="text-left text-slate-500">
+            <tr>
+              {!program && <th className="py-2">Programa</th>}
+              <th className="py-2">Origem</th>
+              <th>Pontos</th>
+              <th>Previsto</th>
+            </tr>
+          </thead>
+          <tbody>
+            {itens.map((m) => (
+              <tr key={m.id} className="border-t">
+                {!program && <td className="py-2 capitalize">{m.program}</td>}
+                <td className="py-2">{m.partner}</td>
+                <td>{m.points}</td>
+                <td>{dayjs(m.expected_at).format('DD/MM/YYYY')}</td>
+              </tr>
+            ))}
+            {itens.length === 0 && (
+              <tr>
+                <td colSpan={colSpan} className="py-10 text-center text-slate-500">
+                  Sem pendências.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+

--- a/src/pages/MilhasAzul.tsx
+++ b/src/pages/MilhasAzul.tsx
@@ -1,4 +1,5 @@
 import MilhasLivelo from './MilhasLivelo';
+
 export default function MilhasAzul() {
-  return <MilhasLivelo />;
+  return <MilhasLivelo program="azul" />;
 }

--- a/src/pages/MilhasHome.tsx
+++ b/src/pages/MilhasHome.tsx
@@ -3,6 +3,7 @@ import { Plane } from 'lucide-react';
 
 import PageHeader from '@/components/PageHeader';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
+import MilesPendingList from '@/components/miles/MilesPendingList';
 
 export default function MilhasHome() {
   const saldoTotal = 12000;
@@ -46,6 +47,8 @@ export default function MilhasHome() {
           </CardContent>
         </Card>
       </div>
+
+      <MilesPendingList />
 
       <div className="grid gap-4 sm:grid-cols-3">
         <Link to="/milhas/livelo" className="block">

--- a/src/pages/MilhasLatam.tsx
+++ b/src/pages/MilhasLatam.tsx
@@ -1,7 +1,6 @@
 import MilhasLivelo from './MilhasLivelo';
+
 export default function MilhasLatam() {
-  // Reuso rápido: mesma página, trocando somente o título/badge
-  // Para personalizar (cores/regras), podemos separar depois.
-  // Como atalho, apenas exporto a versão reutilizada e você muda o título no PageHeader.
-  return <MilhasLivelo />;
+  // Reuso da página principal, alterando apenas o programa.
+  return <MilhasLivelo program="latam" />;
 }

--- a/src/pages/MilhasLivelo.tsx
+++ b/src/pages/MilhasLivelo.tsx
@@ -3,16 +3,17 @@ import dayjs from 'dayjs';
 import { toast } from 'sonner';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
 
-import MilesHeader from '@/components/MilesHeader';
+import MilesHeader, { type MilesProgram } from '@/components/MilesHeader';
 import { MotionCard } from '@/components/ui/MotionCard';
 import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
 import { Button } from '@/components/ui/button';
 import ModalMilesMovement, { type MilesMovement } from '@/components/ModalMilesMovement';
+import MilesPendingList from '@/components/miles/MilesPendingList';
 
 import 'dayjs/locale/pt-br';
 dayjs.locale('pt-br');
 
-export default function MilhasLivelo() {
+export default function MilhasLivelo({ program = 'livelo' }: { program?: MilesProgram }) {
   const [open, setOpen] = useState(false);
   const [edit, setEdit] = useState<MilesMovement | null>(null);
 
@@ -63,9 +64,10 @@ export default function MilhasLivelo() {
 
   return (
     <div className="space-y-6">
-      <MilesHeader program="livelo" subtitle="Saldo, expiração e movimentos">
+      <MilesHeader program={program} subtitle="Saldo, expiração e movimentos">
         <Button onClick={()=>{ setEdit(null); setOpen(true); }}>Novo movimento</Button>
       </MilesHeader>
+      <MilesPendingList program={program} />
 
       {/* KPIs */}
       <section className="grid gap-4 sm:grid-cols-4">


### PR DESCRIPTION
## Summary
- add reusable pending miles list component
- show program-specific pending miles on Livelo, LATAM, and Azul pages
- show consolidated pending miles on the Miles home page

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d565b63b08322ae7832d43912e68c