### PR TITLE
feat: redesign sidebar IA and style

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -2,31 +2,49 @@ import * as React from "react";
 import { NavLink, useLocation, useNavigate } from "react-router-dom";
 import * as RTooltip from "@radix-ui/react-tooltip";
 import {
-  LayoutDashboard, Wallet, CalendarRange, PiggyBank, Landmark, Building2,
-  CandlestickChart, Coins, Target, Plane, Gift, ShoppingCart, Settings,
-  ChevronDown, ChevronsLeft, ChevronsRight,
+  LayoutDashboard,
+  CalendarRange,
+  PiggyBank,
+  Landmark,
+  Building2,
+  CandlestickChart,
+  Coins,
+  Target,
+  Plane,
+  Gift,
+  ShoppingCart,
+  Settings,
+  ChevronDown,
+  ChevronsLeft,
+  ChevronsRight,
 } from "lucide-react";
 
 import { Logo } from "./Logo";
 import { ThemeToggle } from "./ThemeToggle";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "./ui/dropdown-menu";
 
-type NavLeaf = { type: "item"; label: string; to: string; icon?: React.ElementType; title?: string; };
-type NavGroup = { type: "group"; label: string; icon?: React.ElementType; children: NavLeaf[]; };
+import { useAuth } from "@/contexts/AuthContext";
+
+type NavLeaf = { type: "item"; label: string; to: string; icon?: React.ElementType; title?: string };
+type NavGroup = { type: "group"; label: string; icon?: React.ElementType; children: NavLeaf[] };
 type Section = { label: string; items: (NavLeaf | NavGroup)[] };
 
 const sections: Section[] = [
   {
     label: "Geral",
+    items: [{ type: "item", label: "Visão geral", to: "/dashboard", icon: LayoutDashboard }],
+  },
+  {
+    label: "Finanças",
     items: [
-      { type: "item", label: "Visão geral", to: "/dashboard", icon: LayoutDashboard },
-      {
-        type: "group", label: "Finanças", icon: Wallet,
-        children: [
-          { type: "item", label: "Resumo", to: "/financas/resumo", icon: LayoutDashboard },
-          { type: "item", label: "Mensal", to: "/financas/mensal", icon: CalendarRange },
-          { type: "item", label: "Anual", to: "/financas/anual", icon: CalendarRange },
-        ],
-      },
+      { type: "item", label: "Resumo", to: "/financas/resumo", icon: LayoutDashboard },
+      { type: "item", label: "Mensal", to: "/financas/mensal", icon: CalendarRange },
+      { type: "item", label: "Anual", to: "/financas/anual", icon: CalendarRange },
     ],
   },
   {
@@ -34,7 +52,9 @@ const sections: Section[] = [
     items: [
       { type: "item", label: "Resumo", to: "/investimentos", icon: PiggyBank },
       {
-        type: "group", label: "Carteira", icon: Landmark,
+        type: "group",
+        label: "Carteira",
+        icon: Landmark,
         children: [
           { type: "item", label: "Renda Fixa", to: "/investimentos/renda-fixa", icon: Landmark },
           { type: "item", label: "FIIs", to: "/investimentos/fiis", icon: Building2 },
@@ -47,20 +67,12 @@ const sections: Section[] = [
   {
     label: "Planejamento",
     items: [
-      { type: "item", label: "Metas e Projetos", to: "/metas", icon: Target },
-      {
-        type: "group", label: "Milhas", icon: Plane,
-        children: [
-          { type: "item", label: "Livelo", to: "/milhas/livelo", icon: Plane },
-          { type: "item", label: "Latam Pass", to: "/milhas/latampass", icon: Plane },
-          { type: "item", label: "Azul", to: "/milhas/azul", icon: Plane },
-        ],
-      },
+      { type: "item", label: "Metas & Projetos", to: "/metas", icon: Target },
+      { type: "item", label: "Milhas", to: "/milhas", icon: Plane },
       { type: "item", label: "Lista de Desejos", to: "/lista-desejos", icon: Gift },
       { type: "item", label: "Lista de Compras", to: "/lista-compras", icon: ShoppingCart },
     ],
   },
-  { label: "Sistema", items: [{ type: "item", label: "Configurações", to: "/configuracoes", icon: Settings }] },
 ];
 
 const OPEN_KEY = "sb:navOpen";
@@ -69,7 +81,10 @@ const COL_KEY = "sb:collapsed";
 function flattenLeaves(): NavLeaf[] {
   const leaves: NavLeaf[] = [];
   sections.forEach((sec) => {
-    sec.items.forEach((it) => { if (it.type === "group") leaves.push(...it.children); else leaves.push(it); });
+    sec.items.forEach((it) => {
+      if (it.type === "group") leaves.push(...it.children);
+      else leaves.push(it);
+    });
   });
   return leaves;
 }
@@ -78,18 +93,28 @@ export function Sidebar() {
   const location = useLocation();
   const navigate = useNavigate();
   const navRef = React.useRef<HTMLElement | null>(null);
+  const { user, signOut } = useAuth();
+  const initials = user?.email?.slice(0, 2).toUpperCase() ?? "";
 
   const [collapsed, setCollapsed] = React.useState<boolean>(() =>
     typeof window !== "undefined" && localStorage.getItem(COL_KEY) === "1"
   );
 
   const [open, setOpen] = React.useState<Record<string, boolean>>(() => {
-    try { const raw = typeof window !== "undefined" ? localStorage.getItem(OPEN_KEY) : null; return raw ? JSON.parse(raw) : {}; }
-    catch { return {}; }
+    try {
+      const raw = typeof window !== "undefined" ? localStorage.getItem(OPEN_KEY) : null;
+      return raw ? JSON.parse(raw) : {};
+    } catch {
+      return {};
+    }
   });
 
-  React.useEffect(() => { localStorage.setItem(COL_KEY, collapsed ? "1" : "0"); }, [collapsed]);
-  React.useEffect(() => { localStorage.setItem(OPEN_KEY, JSON.stringify(open)); }, [open]);
+  React.useEffect(() => {
+    localStorage.setItem(COL_KEY, collapsed ? "1" : "0");
+  }, [collapsed]);
+  React.useEffect(() => {
+    localStorage.setItem(OPEN_KEY, JSON.stringify(open));
+  }, [open]);
 
   React.useEffect(() => {
     const next: Record<string, boolean> = {};
@@ -113,13 +138,18 @@ export function Sidebar() {
     const leaves = flattenLeaves();
     const path = location.pathname;
     let best: NavLeaf | null = null;
-    for (const leaf of leaves) if (path.startsWith(leaf.to) && (!best || leaf.to.length > best.to.length)) best = leaf;
+    for (const leaf of leaves)
+      if (path.startsWith(leaf.to) && (!best || leaf.to.length > best.to.length)) best = leaf;
     const label = best?.label ?? "Financeiro do Yago";
     document.title = `${label} — Financeiro do Yago`;
   }, [location.pathname]);
 
   const handleGroupClick = (group: NavGroup) => {
-    if (collapsed) { const first = group.children[0]; if (first) navigate(first.to); return; }
+    if (collapsed) {
+      const first = group.children[0];
+      if (first) navigate(first.to);
+      return;
+    }
     setOpen((p) => ({ ...p, [group.label]: !p[group.label] }));
   };
 
@@ -128,112 +158,139 @@ export function Sidebar() {
       <aside
         data-collapsed={collapsed ? "true" : "false"}
         className={[
-          "sticky top-0 h-screen shrink-0 border-r border-slate-800 bg-slate-950/95 backdrop-blur text-slate-200 transition-[width]",
+          "sticky top-0 h-screen shrink-0 border-r border-slate-800/60 bg-slate-950/60 backdrop-blur text-slate-200 transition-[width]",
           collapsed ? "w-20" : "w-72",
         ].join(" ")}
       >
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-800">
-          {/* Logo não aceita className; envolve em uma div */}
-          <div className="h-7 w-7">
-            <Logo />
-          </div>
-          {!collapsed && (
-            <div className="flex flex-col">
-              <span className="text-xs uppercase tracking-widest text-emerald-400/90">Financeiro</span>
-              <span className="text-base font-semibold text-white">do Yago</span>
+        <div className="flex h-full flex-col">
+          <div className="m-2 flex items-center rounded-2xl sidebar-header p-4">
+            <Logo size="lg" />
+            {!collapsed && <span className="ml-2 text-xl font-semibold">FY</span>}
+            <div className="ml-auto flex items-center gap-2">
+              <ThemeToggle className="bg-white/20 text-white hover:bg-white/30" />
+              <NavLink
+                to="/configuracoes"
+                className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-white/20 text-white hover:bg-white/30"
+                title="Configurações"
+              >
+                <Settings className="h-4 w-4" />
+              </NavLink>
+              <button
+                aria-label={collapsed ? "Expandir menu" : "Recolher menu"}
+                title={collapsed ? "Expandir menu" : "Recolher menu"}
+                onClick={() => setCollapsed((v) => !v)}
+                className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-white/20 text-white hover:bg-white/30"
+              >
+                {collapsed ? <ChevronsRight className="h-4 w-4" /> : <ChevronsLeft className="h-4 w-4" />}
+              </button>
             </div>
-          )}
-          <div className="ml-auto flex items-center gap-2">
-            <button
-              aria-label={collapsed ? "Expandir menu" : "Recolher menu"}
-              title={collapsed ? "Expandir menu" : "Recolher menu"}
-              onClick={() => setCollapsed((v) => !v)}
-              className="inline-flex h-8 w-8 items-center justify-center rounded-md hover:bg-white/5 text-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/40"
-            >
-              {collapsed ? <ChevronsRight className="h-4 w-4" /> : <ChevronsLeft className="h-4 w-4" />}
-            </button>
-            <ThemeToggle />
           </div>
-        </div>
 
-        <nav ref={navRef} className="px-2 py-3 overflow-y-auto h-[calc(100vh-56px)]">
-          {sections.map((section) => (
-            <div key={section.label} className="mt-4 first:mt-0">
-              {!collapsed && (
-                <div className="px-3 pb-2 text-[11px] font-semibold uppercase tracking-wider text-slate-400/70">
-                  {section.label}
-                </div>
-              )}
+          <nav ref={navRef} className="flex-1 overflow-y-auto px-2 py-4">
+            {sections.map((section) => (
+              <div key={section.label} className="mt-4 first:mt-0">
+                {!collapsed && (
+                  <div className="px-3 pb-2 text-[11px] font-semibold uppercase tracking-wider text-slate-400/70">
+                    {section.label}
+                  </div>
+                )}
 
-              <ul className="space-y-1">
-                {section.items.map((item) => {
-                  if (item.type === "group") {
-                    const Icon = item.icon ?? Wallet;
-                    const isOpen = !!open[item.label];
+                <ul className="space-y-1">
+                  {section.items.map((item) => {
+                    if (item.type === "group") {
+                      const Icon = item.icon;
+                      const isOpen = !!open[item.label];
 
-                    const ButtonEl = (
-                      <button
-                        onClick={() => handleGroupClick(item)}
-                        className={[
-                          "group flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-slate-300 hover:bg:white/5 hover:bg-white/5 hover:text-white transition",
-                          collapsed ? "justify-center" : "",
-                        ].join(" ")}
-                        aria-expanded={isOpen}
-                        title={collapsed ? item.label : undefined}
-                        aria-label={collapsed ? item.label : undefined}
-                      >
-                        <span className="flex items-center gap-3">
-                          <Icon className="h-4 w-4 text-slate-400 group-hover:text-white" />
-                          {!collapsed && <span className="text-sm font-medium">{item.label}</span>}
-                        </span>
-                        {!collapsed && (
-                          <ChevronDown className={`h-4 w-4 text-slate-400 transition-transform ${isOpen ? "rotate-180" : ""}`} />
-                        )}
-                      </button>
-                    );
+                      const ButtonEl = (
+                        <button
+                          onClick={() => handleGroupClick(item)}
+                          className={[
+                            "group flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-slate-300 hover:bg-emerald-600/10 hover:text-white transition",
+                            collapsed ? "justify-center" : "",
+                          ].join(" ")}
+                          aria-expanded={isOpen}
+                          title={collapsed ? item.label : undefined}
+                          aria-label={collapsed ? item.label : undefined}
+                        >
+                          <span className="flex items-center gap-3">
+                            {Icon && <Icon className="h-4 w-4 text-slate-400 group-hover:text-white" />}
+                            {!collapsed && <span className="text-sm font-medium">{item.label}</span>}
+                          </span>
+                          {!collapsed && (
+                            <ChevronDown className={`h-4 w-4 text-slate-400 transition-transform ${isOpen ? "rotate-180" : ""}`} />
+                          )}
+                        </button>
+                      );
+
+                      return (
+                        <li key={item.label}>
+                          <div className="relative">
+                            {collapsed ? (
+                              <RTooltip.Root>
+                                <RTooltip.Trigger asChild>{ButtonEl}</RTooltip.Trigger>
+                                <RTooltip.Content
+                                  side="right"
+                                  sideOffset={8}
+                                  className="rounded-md bg-slate-900 px-2 py-1 text-xs text-white shadow-lg ring-1 ring-black/20 data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[side=right]:slide-in-from-left-1"
+                                >
+                                  {item.label}
+                                  <RTooltip.Arrow className="fill-slate-900" />
+                                </RTooltip.Content>
+                              </RTooltip.Root>
+                            ) : (
+                              ButtonEl
+                            )}
+                          </div>
+
+                          {!collapsed && isOpen && (
+                            <ul className="mt-1 space-y-1 pl-8">
+                              {item.children.map((child) => (
+                                <li key={child.to}>
+                                  <NavLeafLink leaf={child} />
+                                </li>
+                              ))}
+                            </ul>
+                          )}
+                        </li>
+                      );
+                    }
 
                     return (
-                      <li key={item.label}>
-                        <div className="relative">
-                          {collapsed ? (
-                            <RTooltip.Root>
-                              <RTooltip.Trigger asChild>{ButtonEl}</RTooltip.Trigger>
-                              <RTooltip.Content
-                                side="right" sideOffset={8}
-                                className="rounded-md bg-slate-900 px-2 py-1 text-xs text-white shadow-lg ring-1 ring-black/20 data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[side=right]:slide-in-from-left-1"
-                              >
-                                {item.label}
-                                <RTooltip.Arrow className="fill-slate-900" />
-                              </RTooltip.Content>
-                            </RTooltip.Root>
-                          ) : (
-                            ButtonEl
-                          )}
-                        </div>
-
-                        {!collapsed && isOpen && (
-                          <ul className="mt-1 space-y-1 pl-8">
-                            {item.children.map((child) => (
-                              <li key={child.to}>
-                                <NavLeafLink leaf={child} />
-                              </li>
-                            ))}
-                          </ul>
-                        )}
+                      <li key={item.to}>
+                        <NavLeafLink leaf={item} collapsed={collapsed} />
                       </li>
                     );
-                  }
+                  })}
+                </ul>
+              </div>
+            ))}
+          </nav>
 
-                  return (
-                    <li key={item.to}>
-                      <NavLeafLink leaf={item} collapsed={collapsed} />
-                    </li>
-                  );
-                })}
-              </ul>
-            </div>
-          ))}
-        </nav>
+          <div className="p-2">
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <button className="flex w-full items-center gap-3 rounded-2xl p-2 text-left hover:bg-emerald-600/10 transition">
+                  <div className="flex h-9 w-9 items-center justify-center rounded-full bg-emerald-500 text-sm font-semibold text-white">
+                    {initials}
+                  </div>
+                  {!collapsed && (
+                    <div className="flex min-w-0 flex-col">
+                      <span className="truncate text-sm font-medium">
+                        {user?.user_metadata?.full_name || user?.email}
+                      </span>
+                      <span className="truncate text-xs text-slate-400">{user?.email}</span>
+                    </div>
+                  )}
+                  {!collapsed && <ChevronDown className="ml-auto h-4 w-4 text-slate-400" />}
+                </button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="start" side="top" className="w-40">
+                <DropdownMenuItem onSelect={() => navigate("/perfil")}>Perfil</DropdownMenuItem>
+                <DropdownMenuItem onSelect={signOut}>Sair</DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
+        </div>
       </aside>
     </RTooltip.Provider>
   );
@@ -252,8 +309,10 @@ function NavLeafLink({ leaf, collapsed }: { leaf: NavLeaf; collapsed?: boolean }
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/40",
           collapsed ? "justify-center" : "",
           isActive
-            ? "sb-active bg-emerald-500/15 text-emerald-300 ring-1 ring-emerald-500/30"
-            : "text-slate-300 hover:text-white hover:bg-white/5",
+            ? leaf.label === "Visão geral"
+              ? "sb-active bg-gradient-to-r from-emerald-600/20 to-emerald-400/20 text-emerald-200 ring-2 ring-emerald-400/60"
+              : "sb-active bg-emerald-500/15 text-emerald-300 ring-1 ring-emerald-500/30"
+            : "text-slate-300 hover:text-white hover:bg-emerald-600/10",
         ].join(" ")
       }
     >
@@ -266,7 +325,8 @@ function NavLeafLink({ leaf, collapsed }: { leaf: NavLeaf; collapsed?: boolean }
     <RTooltip.Root>
       <RTooltip.Trigger asChild>{LinkEl}</RTooltip.Trigger>
       <RTooltip.Content
-        side="right" sideOffset={8}
+        side="right"
+        sideOffset={8}
         className="rounded-md bg-slate-900 px-2 py-1 text-xs text-white shadow-lg ring-1 ring-black/20 data-[state=delayed-open]:animate-in data-[state=closed]:animate-out data-[side=right]:slide-in-from-left-1"
       >
         {leaf.label}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -8,7 +8,7 @@ function getInitialTheme(): "light" | "dark" {
   return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
 }
 
-export function ThemeToggle() {
+export function ThemeToggle({ className = "" }: { className?: string }) {
   const [theme, setTheme] = React.useState<"light" | "dark">(getInitialTheme);
 
   React.useEffect(() => {
@@ -23,7 +23,7 @@ export function ThemeToggle() {
       type="button"
       onClick={() => setTheme((t) => (t === "dark" ? "light" : "dark"))}
       aria-label="Alternar tema"
-      className="inline-flex h-9 w-9 items-center justify-center rounded-lg border border-slate-700/60 bg-slate-900/60 text-slate-200 hover:bg-slate-800 hover:text-white transition shadow-sm"
+      className={["inline-flex h-9 w-9 items-center justify-center rounded-xl transition bg-slate-900/60 text-slate-200 hover:bg-slate-800 hover:text-white", className].join(" ")}
     >
       <Sun className="h-4 w-4 block dark:hidden" />
       <Moon className="h-4 w-4 hidden dark:block" />

--- a/src/index.css
+++ b/src/index.css
@@ -11,7 +11,7 @@
 :root {
   /* Colors */
   --color-primary: #009579;
-  --color-secondary: #1E88E5;
+  --color-secondary: #1e88e5;
   --color-neutral: #64748b;
   --color-success: #22c55e;
   --color-warning: #f6be23;
@@ -19,8 +19,9 @@
   --color-surface: #ffffff;
 
   /* Typography */
-  --font-sans: "Inter Variable", ui-sans-serif, system-ui, -apple-system,
-    "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
+  --font-sans:
+    "Inter Variable", ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+    Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
   --font-display: "Sora Variable", var(--font-sans);
 
   /* Spacing */
@@ -36,14 +37,19 @@
   --radius-card: 1.75rem;
 
   /* Shadows */
-  --shadow-sm: 0 1px 2px rgba(0,0,0,0.05);
-  --shadow-md: 0 4px 6px rgba(0,0,0,0.1);
-  --shadow-card: 0 8px 20px rgba(0,0,0,0.08);
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
+  --shadow-card: 0 8px 20px rgba(0, 0, 0, 0.08);
 }
 
 /* Preferência de tema */
-:root { color-scheme: light; }
-.dark { color-scheme: dark; --color-surface: #1e293b; }
+:root {
+  color-scheme: light;
+}
+.dark {
+  color-scheme: dark;
+  --color-surface: #1e293b;
+}
 
 /* Tokens (mantém compatível com shadcn) */
 @layer base {
@@ -75,11 +81,11 @@
     --chart-4: 12 90% 60%;
     --chart-5: 338 78% 62%;
     /* Named chart tokens */
-    --chart-blue: 217 91% 60%;      /* ~blue-500 */
-    --chart-emerald: 160 84% 39%;   /* ~emerald-500 */
-    --chart-rose: 346 77% 57%;      /* ~rose-500 */
-    --chart-violet: 251 89% 68%;    /* ~violet-500 */
-    --chart-amber: 38 92% 58%;      /* ~amber-500 */
+    --chart-blue: 217 91% 60%; /* ~blue-500 */
+    --chart-emerald: 160 84% 39%; /* ~emerald-500 */
+    --chart-rose: 346 77% 57%; /* ~rose-500 */
+    --chart-violet: 251 89% 68%; /* ~violet-500 */
+    --chart-amber: 38 92% 58%; /* ~amber-500 */
     /* Axes & grid */
     --chart-grid: 215 20% 88%;
     --chart-grid-strong: 215 16% 80%;
@@ -88,8 +94,9 @@
     --chart-tooltip-bg: 0 0% 100%;
     --chart-tooltip-fg: 222.2 47.4% 11.2%;
 
-    --font-sans: "Inter Variable", ui-sans-serif, system-ui, -apple-system,
-      "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji",
+    --font-sans:
+      "Inter Variable", ui-sans-serif, system-ui, -apple-system, "Segoe UI",
+      Roboto, "Helvetica Neue", Arial, "Noto Sans", "Apple Color Emoji",
       "Segoe UI Emoji", "Segoe UI Symbol";
     --font-display: "Sora Variable", var(--font-sans);
   }
@@ -122,15 +129,30 @@
     --chart-tooltip-fg: 210 40% 98%;
   }
 
-  * { @apply border-border; }
-  html, body, #root { height: 100%; }
-  html { font-family: var(--font-sans); }
-  body { @apply bg-background text-foreground antialiased; }
-  h1, h2, h3 { font-family: var(--font-display); letter-spacing: -0.02em; }
+  * {
+    @apply border-border;
+  }
+  html,
+  body,
+  #root {
+    height: 100%;
+  }
+  html {
+    font-family: var(--font-sans);
+  }
+  body {
+    @apply bg-background text-foreground antialiased;
+  }
+  h1,
+  h2,
+  h3 {
+    font-family: var(--font-display);
+    letter-spacing: -0.02em;
+  }
   *:focus-visible {
     outline: 2px solid hsl(var(--ring));
     outline-offset: 2px;
-    box-shadow: 0 0 0 2px hsl(var(--ring)/0.4);
+    box-shadow: 0 0 0 2px hsl(var(--ring) / 0.4);
   }
 }
 
@@ -140,8 +162,8 @@ body::after {
   content: "";
   position: fixed;
   inset: 0;
-  z-index: -1;           /* <- garante que não cobre o app */
-  pointer-events: none;  /* <- nunca intercepta cliques */
+  z-index: -1; /* <- garante que não cobre o app */
+  pointer-events: none; /* <- nunca intercepta cliques */
 }
 
 /* Canvas base (sem grid; visual limpo) */
@@ -163,14 +185,29 @@ body::before {
 /* Gradientes radiais nas bordas */
 body::after {
   background:
-    radial-gradient(800px 400px at -10% -10%, hsla(var(--primary), .18), transparent 60%),
-    radial-gradient(900px 500px at 110% -10%, hsla(220, 90%, 60%, .12), transparent 60%),
-    radial-gradient(700px 400px at 50% 120%, hsla(280, 70%, 60%, .10), transparent 60%);
+    radial-gradient(
+      800px 400px at -10% -10%,
+      hsla(var(--primary), 0.18),
+      transparent 60%
+    ),
+    radial-gradient(
+      900px 500px at 110% -10%,
+      hsla(220, 90%, 60%, 0.12),
+      transparent 60%
+    ),
+    radial-gradient(
+      700px 400px at 50% 120%,
+      hsla(280, 70%, 60%, 0.1),
+      transparent 60%
+    );
   filter: saturate(1.1);
 }
 
 /* Cards “glass” utilitário opcional */
 @layer utilities {
+  .sidebar-header {
+    @apply bg-gradient-to-tr from-emerald-600 to-emerald-400 text-white;
+  }
   .glass {
     @apply bg-white/70 backdrop-blur-md border border-white/40 shadow-sm;
   }
@@ -189,24 +226,40 @@ body::after {
   }
   .kpi-icon {
     @apply size-10 rounded-xl flex items-center justify-center text-white shadow-md;
-    background: linear-gradient(135deg, hsl(var(--primary)/.95), hsl(var(--primary)/.7));
+    background: linear-gradient(
+      135deg,
+      hsl(var(--primary) / 0.95),
+      hsl(var(--primary) / 0.7)
+    );
   }
-  .kpi-title { @apply text-sm text-muted-foreground; }
-  .kpi-value { @apply text-2xl sm:text-3xl font-semibold tracking-tight; }
+  .kpi-title {
+    @apply text-sm text-muted-foreground;
+  }
+  .kpi-value {
+    @apply text-2xl sm:text-3xl font-semibold tracking-tight;
+  }
 }
 
 /* Ajuste fino para sidebar */
-:root { --sidebar-border: 1px; }
+:root {
+  --sidebar-border: 1px;
+}
 
 /* === Charts (Recharts) theming — usa tokens acima === */
-.recharts-cartesian-grid line { stroke: hsl(var(--chart-grid)); }
+.recharts-cartesian-grid line {
+  stroke: hsl(var(--chart-grid));
+}
 .recharts-xAxis .recharts-cartesian-axis-line,
-.recharts-yAxis .recharts-cartesian-axis-line { stroke: transparent; }
-.recharts-cartesian-axis-tick-line { stroke: transparent; }
+.recharts-yAxis .recharts-cartesian-axis-line {
+  stroke: transparent;
+}
+.recharts-cartesian-axis-tick-line {
+  stroke: transparent;
+}
 .recharts-tooltip-wrapper .recharts-default-tooltip {
   border-radius: 12px !important;
   border: 1px solid hsl(var(--border)) !important;
   background: hsl(var(--chart-tooltip-bg)) !important;
   color: hsl(var(--chart-tooltip-fg)) !important;
-  box-shadow: 0 10px 30px rgba(0,0,0,.08) !important;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.08) !important;
 }


### PR DESCRIPTION
## Summary
- restructure navigation with standalone highlighted "Visão geral" and reorganized modules
- add glass/gradient sidebar header with theme toggle, settings, and user profile card

## Testing
- `npm run lint` *(fails: Parsing error in existing MilesPendingList.tsx and MilhasLivelo.tsx)*
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d5ae5422083228c6d29651bde9003