### PR TITLE
fix: hide decorative badges and fix z-index layering in dashboard

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -559,37 +559,46 @@ function KpiCard({
     >
       {/* Ícone decorativo sem capturar cliques */}
       <div
-        className="pointer-events-none absolute -right-8 -top-8 h-28 w-28 rounded-full opacity-20 blur-2xl"
+        aria-hidden
+        className="pointer-events-none absolute -right-8 -top-8 z-0 h-28 w-28 rounded-full opacity-25 blur-2xl"
         style={{ background: `linear-gradient(135deg, ${colorFrom}, ${colorTo})` }}
       />
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex items-center gap-2">
-          <div
-            className="kpi-icon"
-            style={{ background: `linear-gradient(135deg, ${colorFrom}, ${colorTo})` }}
+      <div className="relative z-10 flex flex-col">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <div
+              className="kpi-icon"
+              style={{ background: `linear-gradient(135deg, ${colorFrom}, ${colorTo})` }}
+            >
+              {icon}
+            </div>
+            <div>
+              <p className="kpi-title">{title}</p>
+              <p className="kpi-value">
+                <CountUp value={value} />
+              </p>
+            </div>
+          </div>
+          <div className="shrink-0">
+            <Sparkline data={spark} color={sparkColor} />
+          </div>
+        </div>
+        {trend === "up" ? (
+          <span
+            aria-hidden
+            className="pointer-events-none mt-2 inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-1 text-xs font-medium text-emerald-700"
           >
-            {icon}
-          </div>
-          <div>
-            <p className="kpi-title">{title}</p>
-            <p className="kpi-value">
-              <CountUp value={value} />
-            </p>
-          </div>
-        </div>
-        <div className="shrink-0">
-          <Sparkline data={spark} color={sparkColor} />
-        </div>
+            ▲ bom
+          </span>
+        ) : trend === "down" ? (
+          <span
+            aria-hidden
+            className="pointer-events-none mt-2 inline-flex items-center gap-1 rounded-full bg-rose-100 px-2 py-1 text-xs font-medium text-rose-700"
+          >
+            ▼ atenção
+          </span>
+        ) : null}
       </div>
-      {trend === "up" ? (
-        <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-1 text-xs font-medium text-emerald-700">
-          ▲ bom
-        </span>
-      ) : trend === "down" ? (
-        <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-rose-100 px-2 py-1 text-xs font-medium text-rose-700">
-          ▼ atenção
-        </span>
-      ) : null}
     </motion.div>
   );
 }


### PR DESCRIPTION
## Summary
- ensure KPI content layers above decorative badges on Dashboard
- mark arrow badges as decorative to avoid ghost clicks

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Parsing error in unrelated files)
- `npx eslint src/pages/Dashboard.tsx`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d5af7b2c48322b86729ac7ebec2dc