### PR TITLE
feat(milhas): record pending miles on transaction create and show 'A receber' with settlement action

### DIFF
--- a/src/pages/MilhasLivelo.tsx
+++ b/src/pages/MilhasLivelo.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import dayjs from 'dayjs';
 import { toast } from 'sonner';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
+
 import MilesHeader, { type MilesProgram } from '@/components/MilesHeader';
 import PageHeader from '@/components/PageHeader';
 import { MotionCard } from '@/components/ui/MotionCard';
@@ -16,8 +17,7 @@ import azulLogo from '@/assets/logos/azul.svg';
 import 'dayjs/locale/pt-br';
 dayjs.locale('pt-br');
 
-export default function MilhasLivelo({ program = 'livelo' }: { program?: MilesProgram }) {
-type Program = 'livelo' | 'latam' | 'azul';
+type Program = MilesProgram;
 
 const CONFIG: Record<Program, { title: string; gradient: string; logo: string }> = {
   livelo: {
@@ -25,7 +25,7 @@ const CONFIG: Record<Program, { title: string; gradient: string; logo: string }>
     gradient: 'from-fuchsia-600 via-pink-500 to-rose-500',
     logo: liveloLogo,
   },
-  latam: {
+  latampass: {
     title: 'Milhas — LATAM Pass',
     gradient: 'from-red-600 via-rose-600 to-purple-600',
     logo: latamLogo,

--- a/supabase/migrations/20250815000001_add_miles_posted_at.sql
+++ b/supabase/migrations/20250815000001_add_miles_posted_at.sql
@@ -1,0 +1,3 @@
+alter table public.miles
+  add column if not exists posted_at timestamptz;
+


### PR DESCRIPTION
## Summary
- record pending miles and allow marking as credited
- display monthly pending total badge on Miles home
- add migration for miles posted_at column

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d5b4ae11c832288932ee92b2ffc57