### PR TITLE
style(ui): polish hub cards, hero gradient and sidebar details

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -21,8 +21,8 @@ const PageHeader = (props: PageHeaderProps) => {
   return (
     <div
       className={cn(
-        "mb-6 rounded-xl text-white",
-        gradient ? `bg-gradient-to-r ${gradient}` : "bg-gradient-to-r from-emerald-900 to-teal-700"
+        "mb-6 text-white backdrop-blur-sm border-b border-white/10",
+        gradient ? `bg-gradient-to-r ${gradient}` : "bg-gradient-to-r from-emerald-600 to-teal-600"
       )}
     >
       <div className="container mx-auto px-4 py-5 flex items-center justify-between gap-4">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -132,7 +132,7 @@ export function Sidebar() {
           collapsed ? "w-20" : "w-72",
         ].join(" ")}
       >
-        <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-800">
+        <div className="flex items-center gap-3 px-5 py-4 border-b border-slate-800 ring-1 ring-slate-700/50">
           {/* Logo não aceita className; envolve em uma div */}
           <div className="h-7 w-7">
             <Logo />
@@ -156,16 +156,16 @@ export function Sidebar() {
           </div>
         </div>
 
-        <nav ref={navRef} className="px-2 py-3 overflow-y-auto h-[calc(100vh-56px)]">
+        <nav ref={navRef} className="px-3 py-4 overflow-y-auto h-[calc(100vh-56px)] scrollbar-none">
           {sections.map((section) => (
             <div key={section.label} className="mt-4 first:mt-0">
               {!collapsed && (
-                <div className="px-3 pb-2 text-[11px] font-semibold uppercase tracking-wider text-slate-400/70">
+                <div className="px-4 pb-3 text-[11px] font-semibold uppercase tracking-wider text-slate-400/70">
                   {section.label}
                 </div>
               )}
 
-              <ul className="space-y-1">
+              <ul className="space-y-2">
                 {section.items.map((item) => {
                   if (item.type === "group") {
                     const Icon = item.icon ?? Wallet;
@@ -175,7 +175,7 @@ export function Sidebar() {
                       <button
                         onClick={() => handleGroupClick(item)}
                         className={[
-                          "group flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-slate-300 hover:bg:white/5 hover:bg-white/5 hover:text-white transition",
+                          "group flex w-full items-center justify-between rounded-lg px-4 py-3 text-left text-slate-300 hover:bg-white/5 hover:text-white transition",
                           collapsed ? "justify-center" : "",
                         ].join(" ")}
                         aria-expanded={isOpen}
@@ -212,7 +212,7 @@ export function Sidebar() {
                         </div>
 
                         {!collapsed && isOpen && (
-                          <ul className="mt-1 space-y-1 pl-8">
+                          <ul className="mt-2 space-y-2 pl-9">
                             {item.children.map((child) => (
                               <li key={child.to}>
                                 <NavLeafLink leaf={child} />
@@ -248,7 +248,7 @@ function NavLeafLink({ leaf, collapsed }: { leaf: NavLeaf; collapsed?: boolean }
       aria-label={collapsed ? leaf.label : undefined}
       className={({ isActive }) =>
         [
-          "group relative flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition",
+          "group relative flex items-center gap-3 rounded-lg px-4 py-3 text-sm font-medium transition",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/40",
           collapsed ? "justify-center" : "",
           isActive

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -481,7 +481,7 @@ export default function Dashboard() {
 // ---------------------------------- partials
 function HeroHeader() {
   return (
-    <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-r from-emerald-600 via-teal-600 to-indigo-600 p-6 text-white shadow-lg">
+    <div className="relative overflow-hidden rounded-2xl border-b border-white/10 bg-gradient-to-r from-emerald-600 to-teal-600 p-6 text-white backdrop-blur-sm shadow-lg">
       {/* logo + título, sem descrição */}
       <div className="relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div className="flex items-center gap-3">
@@ -617,17 +617,17 @@ function CardFooterAction({ to, label }: { to: string; label: string }) {
 
 function QuickLink({ to, icon, title, desc }: { to: string; icon: ReactNode; title: string; desc: string }) {
   return (
-    <Card>
-      <div className="mb-2 flex items-center gap-3">
-        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-600 ring-1 ring-emerald-500/30">
+    <Card className="border-none bg-gradient-to-br from-emerald-600 to-teal-600 p-4 text-white shadow-sm transition-transform hover:scale-[1.01]">
+      <div className="mb-3 flex items-center gap-3">
+        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/20 text-white ring-1 ring-white/30">
           {icon}
         </span>
         <span className="font-semibold">{title}</span>
       </div>
-      <div className="mb-4 text-sm text-zinc-500">{desc}</div>
+      <div className="mb-4 text-sm text-white/80">{desc}</div>
       <Link
         to={to}
-        className="inline-block rounded-lg bg-emerald-600/90 px-4 py-2 text-sm font-medium text-white shadow transition hover:bg-emerald-700"
+        className="inline-block rounded-lg bg-white/20 px-4 py-2 text-sm font-medium text-white ring-1 ring-white/30 transition hover:bg-white/30"
       >
         Abrir
       </Link>

--- a/src/pages/HomeOverview.tsx
+++ b/src/pages/HomeOverview.tsx
@@ -13,56 +13,56 @@ export default function HomeOverview() {
       />
       <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
         <Link to="/financas/resumo" className="block">
-          <Card className="p-6 flex items-center gap-4">
+          <Card className="flex items-center gap-4 p-6 border-none bg-gradient-to-br from-emerald-600 to-teal-600 text-white shadow-sm transition-transform hover:scale-[1.01]">
             <TrendingUp className="h-6 w-6" />
             <div>
               <div className="font-semibold">Finanças</div>
-              <div className="text-sm text-muted-foreground">Resumo mensal e anual</div>
+              <div className="text-sm text-white/80">Resumo mensal e anual</div>
             </div>
           </Card>
         </Link>
         <Link to="/investimentos" className="block">
-          <Card className="p-6 flex items-center gap-4">
+          <Card className="flex items-center gap-4 p-6 border-none bg-gradient-to-br from-emerald-600 to-teal-600 text-white shadow-sm transition-transform hover:scale-[1.01]">
             <Wallet className="h-6 w-6" />
             <div>
               <div className="font-semibold">Investimentos</div>
-              <div className="text-sm text-muted-foreground">Resumo e carteira</div>
+              <div className="text-sm text-white/80">Resumo e carteira</div>
             </div>
           </Card>
         </Link>
         <Link to="/metas" className="block">
-          <Card className="p-6 flex items-center gap-4">
+          <Card className="flex items-center gap-4 p-6 border-none bg-gradient-to-br from-emerald-600 to-teal-600 text-white shadow-sm transition-transform hover:scale-[1.01]">
             <Target className="h-6 w-6" />
             <div>
               <div className="font-semibold">Metas & Projetos</div>
-              <div className="text-sm text-muted-foreground">Progresso e aportes</div>
+              <div className="text-sm text-white/80">Progresso e aportes</div>
             </div>
           </Card>
         </Link>
         <Link to="/milhas" className="block">
-          <Card className="p-6 flex items-center gap-4">
+          <Card className="flex items-center gap-4 p-6 border-none bg-gradient-to-br from-emerald-600 to-teal-600 text-white shadow-sm transition-transform hover:scale-[1.01]">
             <Plane className="h-6 w-6" />
             <div>
               <div className="font-semibold">Milhas</div>
-              <div className="text-sm text-muted-foreground">Saldo, a receber e expiração</div>
+              <div className="text-sm text-white/80">Saldo, a receber e expiração</div>
             </div>
           </Card>
         </Link>
         <Link to="/lista-desejos" className="block">
-          <Card className="p-6 flex items-center gap-4">
+          <Card className="flex items-center gap-4 p-6 border-none bg-gradient-to-br from-emerald-600 to-teal-600 text-white shadow-sm transition-transform hover:scale-[1.01]">
             <Heart className="h-6 w-6" />
             <div>
               <div className="font-semibold">Lista de desejos</div>
-              <div className="text-sm text-muted-foreground">Planejamento de compras</div>
+              <div className="text-sm text-white/80">Planejamento de compras</div>
             </div>
           </Card>
         </Link>
         <Link to="/lista-compras" className="block">
-          <Card className="p-6 flex items-center gap-4">
+          <Card className="flex items-center gap-4 p-6 border-none bg-gradient-to-br from-emerald-600 to-teal-600 text-white shadow-sm transition-transform hover:scale-[1.01]">
             <ShoppingCart className="h-6 w-6" />
             <div>
               <div className="font-semibold">Lista de compras</div>
-              <div className="text-sm text-muted-foreground">Itens e orçamentos</div>
+              <div className="text-sm text-white/80">Itens e orçamentos</div>
             </div>
           </Card>
         </Link>


### PR DESCRIPTION
## Summary
- restyle hub cards with emerald-teal gradient, soft shadow and hover scale
- add emerald-teal gradient hero bar with blur and bottom line
- widen sidebar spacing, hide scrollbar and ring header

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error in MilesPendingList.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_689d5b8068b083228ddaec497f84497a