### PR TITLE
feat: add unified miles header

### DIFF
--- a/src/components/BrandIcon.tsx
+++ b/src/components/BrandIcon.tsx
@@ -52,6 +52,7 @@ const BRAND_MAP: Record<string, string> = {
 
   // Aéreas
   latam: "simple-icons:latamairlines",
+  latampass: "simple-icons:latamairlines",
   gol: "simple-icons:gol",
   azul: "simple-icons:azul",
 

--- a/src/components/MilesHeader.tsx
+++ b/src/components/MilesHeader.tsx
@@ -1,30 +1,49 @@
 import type { ReactNode } from 'react';
-import { Icon } from '@iconify/react';
 
-export type MilesProgram = 'livelo' | 'latam' | 'azul';
+import LiveloLogo from '@/assets/logos/livelo.svg?react';
+import LatamPassLogo from '@/assets/logos/latampass.svg?react';
+import AzulLogo from '@/assets/logos/azul.svg?react';
 
-const PROGRAM: Record<MilesProgram, { label: string; icon: string; gradient: string }> = {
-  livelo: { label: 'Livelo', icon: 'simple-icons:livelo', gradient: 'from-fuchsia-600 to-pink-500' },
-  latam: { label: 'LATAM Pass', icon: 'simple-icons:latamairlines', gradient: 'from-rose-600 to-purple-600' },
-  azul: { label: 'Azul', icon: 'simple-icons:azul', gradient: 'from-sky-600 to-blue-700' },
-};
+type Program = 'livelo' | 'latampass' | 'azul';
 
-export default function MilesHeader({ program, subtitle, children }: { program: MilesProgram; subtitle?: string; children?: ReactNode }) {
-  const cfg = PROGRAM[program];
+const BRAND = {
+  livelo: { name: 'Livelo', color: '#7A1FA2', accent: '#FF2D8D', Logo: LiveloLogo },
+  latampass: { name: 'LATAM Pass', color: '#862633', accent: '#E51C44', Logo: LatamPassLogo },
+  azul: { name: 'Azul', color: '#1BA1E2', accent: '#0070AD', Logo: AzulLogo },
+} as const;
+
+export type MilesProgram = Program;
+
+export default function MilesHeader({
+  program,
+  subtitle = 'Saldo, a receber e expiração',
+  children,
+}: {
+  program: Program;
+  subtitle?: string;
+  children?: ReactNode;
+}) {
+  const { name, color, accent, Logo } = BRAND[program];
   return (
-    <header className={`mb-6 rounded-xl bg-gradient-to-r ${cfg.gradient} text-white`}>
-      <div className="container mx-auto px-4 py-5 flex items-center justify-between gap-4">
-        <div className="flex items-center gap-3 min-w-0">
-          <Icon icon={cfg.icon} className="h-7 w-7 shrink-0" />
-          <div className="min-w-0">
-            <h1 className="text-xl font-semibold">Milhas — {cfg.label}</h1>
-            {subtitle ? (
-              <p className="text-white/80 text-sm leading-relaxed truncate">{subtitle}</p>
-            ) : null}
+    <div
+      className="relative overflow-hidden rounded-2xl border"
+      style={{
+        borderColor: `${color}33`,
+        background: `radial-gradient(1200px 400px at 10% -10%, ${accent}26, transparent 60%),\n                     radial-gradient(800px 300px at 110% 10%, ${color}26, transparent 50%)`,
+      }}
+    >
+      <div className="flex items-center justify-between gap-3 p-5">
+        <div className="flex items-center gap-3">
+          <div className="rounded-xl p-2" style={{ background: `${color}22` }}>
+            <Logo className="h-7 w-7" />
+          </div>
+          <div>
+            <h1 className="text-xl font-semibold">{name} — Milhas</h1>
+            {subtitle ? <p className="text-sm opacity-75">{subtitle}</p> : null}
           </div>
         </div>
         {children ? <div className="shrink-0">{children}</div> : null}
       </div>
-    </header>
+    </div>
   );
 }

--- a/src/components/miles/MilesPendingList.tsx
+++ b/src/components/miles/MilesPendingList.tsx
@@ -1,78 +1,3 @@
-import dayjs from 'dayjs';
-import { useMemo } from 'react';
-
-import type { MilesProgram } from '@/components/MilesHeader';
-
-export type MilesPending = {
-  id: string;
-  program: MilesProgram;
-  partner: string;
-  points: number;
-  expected_at: string; // YYYY-MM-DD
-};
-
-// Dados mockados; integração futura com backend/Supabase
-const MOCK: MilesPending[] = [
-  {
-    id: '1',
-    program: 'livelo',
-    partner: 'Compra Loja X',
-    points: 500,
-    expected_at: dayjs().add(10, 'day').format('YYYY-MM-DD'),
-  },
-  {
-    id: '2',
-    program: 'latam',
-    partner: 'Cartão de crédito',
-    points: 1000,
-    expected_at: dayjs().add(30, 'day').format('YYYY-MM-DD'),
-  },
-  {
-    id: '3',
-    program: 'azul',
-    partner: 'Hotel',
-    points: 800,
-    expected_at: dayjs().add(20, 'day').format('YYYY-MM-DD'),
-  },
-];
-
-export default function MilesPendingList({ program }: { program?: MilesProgram }) {
-  const itens = useMemo(() => MOCK.filter((m) => !program || m.program === program), [program]);
-  const colSpan = program ? 3 : 4;
-
-  return (
-    <div className="rounded-xl border bg-white dark:bg-slate-900 p-4">
-      <h3 className="font-medium mb-3">A receber</h3>
-      <div className="overflow-x-auto">
-        <table className="min-w-full text-sm">
-          <thead className="text-left text-slate-500">
-            <tr>
-              {!program && <th className="py-2">Programa</th>}
-              <th className="py-2">Origem</th>
-              <th>Pontos</th>
-              <th>Previsto</th>
-            </tr>
-          </thead>
-          <tbody>
-            {itens.map((m) => (
-              <tr key={m.id} className="border-t">
-                {!program && <td className="py-2 capitalize">{m.program}</td>}
-                <td className="py-2">{m.partner}</td>
-                <td>{m.points}</td>
-                <td>{dayjs(m.expected_at).format('DD/MM/YYYY')}</td>
-              </tr>
-            ))}
-            {itens.length === 0 && (
-              <tr>
-                <td colSpan={colSpan} className="py-10 text-center text-slate-500">
-                  Sem pendências.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
-    </div>
 import { useEffect, useMemo, useState } from "react";
 import dayjs from "dayjs";
 import { toast } from "sonner";
@@ -166,8 +91,7 @@ export default function MilesPendingList({ program }: { program?: Program }) {
               {rows.map((r) => {
                 const d = r.expected_at ? dayjs(r.expected_at) : null;
                 const diff = d ? d.diff(dayjs(), "day") : null;
-                const diffLabel =
-                  diff === null ? "—" : diff === 0 ? "hoje" : diff > 0 ? `${diff}d` : `${diff}d`;
+                const diffLabel = diff === null ? "—" : diff === 0 ? "hoje" : `${diff}d`;
                 const diffClass =
                   diff === null
                     ? "text-muted-foreground"
@@ -199,4 +123,3 @@ export default function MilesPendingList({ program }: { program?: Program }) {
     </Card>
   );
 }
-

--- a/src/pages/MilhasLatam.tsx
+++ b/src/pages/MilhasLatam.tsx
@@ -2,6 +2,5 @@ import MilhasLivelo from './MilhasLivelo';
 
 export default function MilhasLatam() {
   // Reuso da página principal, alterando apenas o programa.
-  
-  return <MilhasLivelo program="latam" />;
+  return <MilhasLivelo program="latampass" />;
 }

--- a/src/pages/MilhasLivelo.tsx
+++ b/src/pages/MilhasLivelo.tsx
@@ -2,7 +2,8 @@ import { useMemo, useState } from 'react';
 import dayjs from 'dayjs';
 import { toast } from 'sonner';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
-import MilesHeader, { type MilesProgram } from '@/components/MilesHeader';
+
+import MilesHeader from '@/components/MilesHeader';
 import PageHeader from '@/components/PageHeader';
 import { MotionCard } from '@/components/ui/MotionCard';
 import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
@@ -16,8 +17,7 @@ import azulLogo from '@/assets/logos/azul.svg';
 import 'dayjs/locale/pt-br';
 dayjs.locale('pt-br');
 
-export default function MilhasLivelo({ program = 'livelo' }: { program?: MilesProgram }) {
-type Program = 'livelo' | 'latam' | 'azul';
+type Program = 'livelo' | 'latampass' | 'azul';
 
 const CONFIG: Record<Program, { title: string; gradient: string; logo: string }> = {
   livelo: {
@@ -25,7 +25,7 @@ const CONFIG: Record<Program, { title: string; gradient: string; logo: string }>
     gradient: 'from-fuchsia-600 via-pink-500 to-rose-500',
     logo: liveloLogo,
   },
-  latam: {
+  latampass: {
     title: 'Milhas — LATAM Pass',
     gradient: 'from-red-600 via-rose-600 to-purple-600',
     logo: latamLogo,


### PR DESCRIPTION
## Summary
- add brand-aware miles header
- support LATAM Pass slug and branding

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d5ceb15e08322b3df8121aa7577c2