### PR TITLE
fix(dashboard): hide decorative badges and fix z-index layering

### DIFF
--- a/src/components/miles/MilesPendingList.tsx
+++ b/src/components/miles/MilesPendingList.tsx
@@ -1,78 +1,3 @@
-import dayjs from 'dayjs';
-import { useMemo } from 'react';
-
-import type { MilesProgram } from '@/components/MilesHeader';
-
-export type MilesPending = {
-  id: string;
-  program: MilesProgram;
-  partner: string;
-  points: number;
-  expected_at: string; // YYYY-MM-DD
-};
-
-// Dados mockados; integração futura com backend/Supabase
-const MOCK: MilesPending[] = [
-  {
-    id: '1',
-    program: 'livelo',
-    partner: 'Compra Loja X',
-    points: 500,
-    expected_at: dayjs().add(10, 'day').format('YYYY-MM-DD'),
-  },
-  {
-    id: '2',
-    program: 'latam',
-    partner: 'Cartão de crédito',
-    points: 1000,
-    expected_at: dayjs().add(30, 'day').format('YYYY-MM-DD'),
-  },
-  {
-    id: '3',
-    program: 'azul',
-    partner: 'Hotel',
-    points: 800,
-    expected_at: dayjs().add(20, 'day').format('YYYY-MM-DD'),
-  },
-];
-
-export default function MilesPendingList({ program }: { program?: MilesProgram }) {
-  const itens = useMemo(() => MOCK.filter((m) => !program || m.program === program), [program]);
-  const colSpan = program ? 3 : 4;
-
-  return (
-    <div className="rounded-xl border bg-white dark:bg-slate-900 p-4">
-      <h3 className="font-medium mb-3">A receber</h3>
-      <div className="overflow-x-auto">
-        <table className="min-w-full text-sm">
-          <thead className="text-left text-slate-500">
-            <tr>
-              {!program && <th className="py-2">Programa</th>}
-              <th className="py-2">Origem</th>
-              <th>Pontos</th>
-              <th>Previsto</th>
-            </tr>
-          </thead>
-          <tbody>
-            {itens.map((m) => (
-              <tr key={m.id} className="border-t">
-                {!program && <td className="py-2 capitalize">{m.program}</td>}
-                <td className="py-2">{m.partner}</td>
-                <td>{m.points}</td>
-                <td>{dayjs(m.expected_at).format('DD/MM/YYYY')}</td>
-              </tr>
-            ))}
-            {itens.length === 0 && (
-              <tr>
-                <td colSpan={colSpan} className="py-10 text-center text-slate-500">
-                  Sem pendências.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
-    </div>
 import { useEffect, useMemo, useState } from "react";
 import dayjs from "dayjs";
 import { toast } from "sonner";
@@ -82,7 +7,7 @@ import { useAuth } from "@/contexts/AuthContext";
 import { Card } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 
-type Program = "livelo" | "latampass" | "azul";
+type Program = "livelo" | "latam" | "azul";
 
 type MileRow = {
   id: number;
@@ -142,9 +67,21 @@ export default function MilesPendingList({ program }: { program?: Program }) {
     <Card className="p-4">
       <div className="mb-3 flex items-center justify-between">
         <div className="font-medium">
-          A receber {program ? `— ${program === "livelo" ? "Livelo" : program === "latampass" ? "LATAM Pass" : "Azul"}` : ""}
+          A receber {
+            program
+              ? `— ${
+                  program === "livelo"
+                    ? "Livelo"
+                    : program === "latam"
+                    ? "LATAM Pass"
+                    : "Azul"
+                }`
+              : ""
+          }
         </div>
-        <div className="text-sm text-muted-foreground">Total: {total.toLocaleString("pt-BR")} pts</div>
+        <div className="text-sm text-muted-foreground">
+          Total: {total.toLocaleString("pt-BR")} pts
+        </div>
       </div>
       {loading ? (
         <div className="text-sm text-muted-foreground">Carregando…</div>
@@ -167,7 +104,7 @@ export default function MilesPendingList({ program }: { program?: Program }) {
                 const d = r.expected_at ? dayjs(r.expected_at) : null;
                 const diff = d ? d.diff(dayjs(), "day") : null;
                 const diffLabel =
-                  diff === null ? "—" : diff === 0 ? "hoje" : diff > 0 ? `${diff}d` : `${diff}d`;
+                  diff === null ? "—" : diff === 0 ? "hoje" : `${diff}d`;
                 const diffClass =
                   diff === null
                     ? "text-muted-foreground"
@@ -179,11 +116,17 @@ export default function MilesPendingList({ program }: { program?: Program }) {
                 return (
                   <tr key={r.id} className="border-b last:border-none">
                     <td className="py-2 capitalize">{r.program}</td>
-                    <td className="py-2 text-right">{r.amount.toLocaleString("pt-BR")}</td>
-                    <td className="py-2">
-                      {r.expected_at ? dayjs(r.expected_at).format("DD/MM/YYYY") : "—"}
+                    <td className="py-2 text-right">
+                      {r.amount.toLocaleString("pt-BR")}
                     </td>
-                    <td className={`py-2 text-center font-medium ${diffClass}`}>{diffLabel}</td>
+                    <td className="py-2">
+                      {r.expected_at
+                        ? dayjs(r.expected_at).format("DD/MM/YYYY")
+                        : "—"}
+                    </td>
+                    <td className={`py-2 text-center font-medium ${diffClass}`}>
+                      {diffLabel}
+                    </td>
                     <td className="py-2 text-right">
                       <Button size="sm" onClick={() => markPosted(r.id)}>
                         Marcar como creditado

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -161,7 +161,7 @@ export default function Dashboard() {
   ];
 
   const { mode, month, year } = usePeriod();
-    const fluxoTitle = `Fluxo de caixa — ${mode === "monthly" ? `${monthShortPtBR(month)} ${year}` : `Ano ${year}`}`;
+  const fluxoTitle = `Fluxo de caixa — ${mode === "monthly" ? `${monthShortPtBR(month)} ${year}` : `Ano ${year}`}`;
 
   const container = { hidden: { opacity: 0, y: 6 }, show: { opacity: 1, y: 0, transition: { staggerChildren: 0.06 } } };
   const item = { hidden: { opacity: 0, y: 8 }, show: { opacity: 1, y: 0 } };

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -25,6 +25,8 @@ import {
   Target,
   Plane,
   PieChart as PieChartIcon,
+  ArrowUpRight,
+  ArrowDownRight,
 } from "lucide-react";
 
 import BrandIcon from "@/components/BrandIcon";
@@ -559,36 +561,41 @@ function KpiCard({
     >
       {/* Ícone decorativo sem capturar cliques */}
       <div
-        className="pointer-events-none absolute -right-8 -top-8 h-28 w-28 rounded-full opacity-20 blur-2xl"
+        aria-hidden
+        className="pointer-events-none absolute -right-8 -top-8 z-0 h-28 w-28 rounded-full opacity-25 blur-2xl"
         style={{ background: `linear-gradient(135deg, ${colorFrom}, ${colorTo})` }}
       />
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex items-center gap-2">
-          <div
-            className="kpi-icon"
-            style={{ background: `linear-gradient(135deg, ${colorFrom}, ${colorTo})` }}
-          >
-            {icon}
+      <div className="relative z-10 flex flex-col">
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-2">
+            <div
+              className="kpi-icon"
+              style={{ background: `linear-gradient(135deg, ${colorFrom}, ${colorTo})` }}
+            >
+              {icon}
+            </div>
+            <div>
+              <p className="kpi-title">{title}</p>
+              <p className="kpi-value">
+                <CountUp value={value} />
+              </p>
+            </div>
           </div>
-          <div>
-            <p className="kpi-title">{title}</p>
-            <p className="kpi-value">
-              <CountUp value={value} />
-            </p>
+          <div className="shrink-0">
+            <Sparkline data={spark} color={sparkColor} />
           </div>
-        </div>
-        <div className="shrink-0">
-          <Sparkline data={spark} color={sparkColor} />
         </div>
       </div>
       {trend === "up" ? (
-        <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-1 text-xs font-medium text-emerald-700">
-          ▲ bom
-        </span>
+        <ArrowUpRight
+          aria-hidden
+          className="pointer-events-none absolute right-2 top-2 z-0 h-12 w-12 text-emerald-600 opacity-25"
+        />
       ) : trend === "down" ? (
-        <span className="mt-2 inline-flex items-center gap-1 rounded-full bg-rose-100 px-2 py-1 text-xs font-medium text-rose-700">
-          ▼ atenção
-        </span>
+        <ArrowDownRight
+          aria-hidden
+          className="pointer-events-none absolute right-2 top-2 z-0 h-12 w-12 text-rose-600 opacity-25"
+        />
       ) : null}
     </motion.div>
   );


### PR DESCRIPTION
## Summary
- hide decorative KPI badges behind content and make them non-interactive
- ensure KPI content renders above decorative elements with proper z-index
- remove duplicate MilesPendingList implementation and restore MilhasLivelo page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d5b02e294832296299e7d1431560e