### PR TITLE
feat: inline logos and brand palettes for miles

### DIFF
--- a/src/components/BrandBadge.tsx
+++ b/src/components/BrandBadge.tsx
@@ -1,22 +1,14 @@
+import { BRANDS, type MilesProgram } from '@/components/miles/brandConfig';
 
-export type MilesBrand = 'livelo' | 'latampass' | 'azul';
+export type MilesBrand = MilesProgram;
 
-export const BRAND_STYLE: Record<MilesBrand, { bg: string; text: string; label: string }> = {
-  livelo:    { bg: 'from-fuchsia-600 to-pink-500', text: 'text-white',      label: 'Livelo' },
-  latampass: { bg: 'from-rose-600 to-purple-600',   text: 'text-white',      label: 'LATAM Pass' },
-  azul:      { bg: 'from-sky-600 to-blue-700',      text: 'text-white',      label: 'Azul' },
-};
-
-export function BrandBadge({ brand, className='' }: { brand: MilesBrand; className?: string }) {
-  const s = BRAND_STYLE[brand];
+export function BrandBadge({ brand, className = '' }: { brand: MilesBrand; className?: string }) {
+  const cfg = BRANDS[brand];
+  const Logo = cfg.Logo;
   return (
-    <div className={`inline-flex items-center gap-2 rounded-xl px-3 py-2 bg-gradient-to-br ${s.bg} ${s.text} ${className}`}>
-      {/* Ícone simples genérico */}
-      <svg width="18" height="18" viewBox="0 0 24 24" className="opacity-95">
-        <path d="M3 12c3-2 6-2 9 0s6 2 9 0" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/>
-        <circle cx="12" cy="12" r="2" fill="currentColor" />
-      </svg>
-      <span className="text-sm font-semibold">{s.label}</span>
+    <div className={`inline-flex items-center gap-2 rounded-xl px-3 py-2 bg-gradient-to-br ${cfg.gradient} text-white ${className}`}>
+      <Logo className="h-4 w-4 opacity-95" />
+      <span className="text-sm font-semibold">{cfg.label}</span>
     </div>
   );
 }

--- a/src/components/MilesHeader.tsx
+++ b/src/components/MilesHeader.tsx
@@ -1,21 +1,17 @@
 import type { ReactNode } from 'react';
-import { Icon } from '@iconify/react';
 
-export type MilesProgram = 'livelo' | 'latam' | 'azul';
+import { BRANDS, type MilesProgram } from '@/components/miles/brandConfig';
 
-const PROGRAM: Record<MilesProgram, { label: string; icon: string; gradient: string }> = {
-  livelo: { label: 'Livelo', icon: 'simple-icons:livelo', gradient: 'from-fuchsia-600 to-pink-500' },
-  latam: { label: 'LATAM Pass', icon: 'simple-icons:latamairlines', gradient: 'from-rose-600 to-purple-600' },
-  azul: { label: 'Azul', icon: 'simple-icons:azul', gradient: 'from-sky-600 to-blue-700' },
-};
+export type { MilesProgram } from '@/components/miles/brandConfig';
 
 export default function MilesHeader({ program, subtitle, children }: { program: MilesProgram; subtitle?: string; children?: ReactNode }) {
-  const cfg = PROGRAM[program];
+  const cfg = BRANDS[program];
+  const Logo = cfg.Logo;
   return (
     <header className={`mb-6 rounded-xl bg-gradient-to-r ${cfg.gradient} text-white`}>
       <div className="container mx-auto px-4 py-5 flex items-center justify-between gap-4">
         <div className="flex items-center gap-3 min-w-0">
-          <Icon icon={cfg.icon} className="h-7 w-7 shrink-0" />
+          <Logo className="h-7 w-7 shrink-0" />
           <div className="min-w-0">
             <h1 className="text-xl font-semibold">Milhas — {cfg.label}</h1>
             {subtitle ? (

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,7 +1,7 @@
 // src/components/PageHeader.tsx
-import type { ReactNode } from "react";
+import type { ReactNode } from 'react';
 
-import { cn } from "@/lib/utils";
+import { cn } from '@/lib/utils';
 
 export type Breadcrumb = { label: string; href?: string };
 
@@ -14,20 +14,23 @@ export type PageHeaderProps = {
   children?: ReactNode;
   gradient?: string;
   logoSrc?: string;
+  logo?: ReactNode;
 };
 
 const PageHeader = (props: PageHeaderProps) => {
-  const { title, subtitle, icon, actions, breadcrumbs, children, gradient, logoSrc } = props;
+  const { title, subtitle, icon, actions, breadcrumbs, children, gradient, logoSrc, logo } = props;
   return (
     <div
       className={cn(
-        "mb-6 rounded-xl text-white",
-        gradient ? `bg-gradient-to-r ${gradient}` : "bg-gradient-to-r from-emerald-900 to-teal-700"
+        'mb-6 rounded-xl text-white',
+        gradient ? `bg-gradient-to-r ${gradient}` : 'bg-gradient-to-r from-emerald-900 to-teal-700'
       )}
     >
       <div className="container mx-auto px-4 py-5 flex items-center justify-between gap-4">
         <div className="flex items-center gap-3 min-w-0">
-          {logoSrc ? (
+          {logo ? (
+            <div className="h-8 w-8 shrink-0 rounded-md flex items-center justify-center">{logo}</div>
+          ) : logoSrc ? (
             <img src={logoSrc} alt="" className="h-8 w-8 shrink-0 rounded-md" />
           ) : icon ? (
             <div className="rounded-lg bg-white/10 p-2 shrink-0">{icon}</div>
@@ -66,5 +69,3 @@ const PageHeader = (props: PageHeaderProps) => {
 };
 
 export default PageHeader;
-// já exportado acima; remover duplicidade para evitar conflito TS
-// export type { Breadcrumb, PageHeaderProps };

--- a/src/components/miles/MilesPendingList.tsx
+++ b/src/components/miles/MilesPendingList.tsx
@@ -1,100 +1,24 @@
+import { useEffect, useMemo, useState } from 'react';
 import dayjs from 'dayjs';
-import { useMemo } from 'react';
+import { toast } from 'sonner';
 
-import type { MilesProgram } from '@/components/MilesHeader';
-
-export type MilesPending = {
-  id: string;
-  program: MilesProgram;
-  partner: string;
-  points: number;
-  expected_at: string; // YYYY-MM-DD
-};
-
-// Dados mockados; integração futura com backend/Supabase
-const MOCK: MilesPending[] = [
-  {
-    id: '1',
-    program: 'livelo',
-    partner: 'Compra Loja X',
-    points: 500,
-    expected_at: dayjs().add(10, 'day').format('YYYY-MM-DD'),
-  },
-  {
-    id: '2',
-    program: 'latam',
-    partner: 'Cartão de crédito',
-    points: 1000,
-    expected_at: dayjs().add(30, 'day').format('YYYY-MM-DD'),
-  },
-  {
-    id: '3',
-    program: 'azul',
-    partner: 'Hotel',
-    points: 800,
-    expected_at: dayjs().add(20, 'day').format('YYYY-MM-DD'),
-  },
-];
-
-export default function MilesPendingList({ program }: { program?: MilesProgram }) {
-  const itens = useMemo(() => MOCK.filter((m) => !program || m.program === program), [program]);
-  const colSpan = program ? 3 : 4;
-
-  return (
-    <div className="rounded-xl border bg-white dark:bg-slate-900 p-4">
-      <h3 className="font-medium mb-3">A receber</h3>
-      <div className="overflow-x-auto">
-        <table className="min-w-full text-sm">
-          <thead className="text-left text-slate-500">
-            <tr>
-              {!program && <th className="py-2">Programa</th>}
-              <th className="py-2">Origem</th>
-              <th>Pontos</th>
-              <th>Previsto</th>
-            </tr>
-          </thead>
-          <tbody>
-            {itens.map((m) => (
-              <tr key={m.id} className="border-t">
-                {!program && <td className="py-2 capitalize">{m.program}</td>}
-                <td className="py-2">{m.partner}</td>
-                <td>{m.points}</td>
-                <td>{dayjs(m.expected_at).format('DD/MM/YYYY')}</td>
-              </tr>
-            ))}
-            {itens.length === 0 && (
-              <tr>
-                <td colSpan={colSpan} className="py-10 text-center text-slate-500">
-                  Sem pendências.
-                </td>
-              </tr>
-            )}
-          </tbody>
-        </table>
-      </div>
-    </div>
-import { useEffect, useMemo, useState } from "react";
-import dayjs from "dayjs";
-import { toast } from "sonner";
-
-import { supabase } from "@/lib/supabaseClient";
-import { useAuth } from "@/contexts/AuthContext";
-import { Card } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-
-type Program = "livelo" | "latampass" | "azul";
+import { supabase } from '@/lib/supabaseClient';
+import { useAuth } from '@/contexts/AuthContext';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { BRANDS, type MilesProgram } from '@/components/miles/brandConfig';
 
 type MileRow = {
   id: number;
   user_id: string;
-  program: Program;
+  program: MilesProgram;
   amount: number;
   expected_at: string | null;
-  status: "pending" | "posted" | "expired";
+  status: 'pending' | 'posted' | 'expired';
   transaction_id: number | null;
 };
 
-export default function MilesPendingList({ program }: { program?: Program }) {
+export default function MilesPendingList({ program }: { program?: MilesProgram }) {
   const { user } = useAuth();
   const [rows, setRows] = useState<MileRow[] | null>(null);
   const [loading, setLoading] = useState(true);
@@ -103,12 +27,12 @@ export default function MilesPendingList({ program }: { program?: Program }) {
     if (!user) return;
     setLoading(true);
     let q = supabase
-      .from("miles")
-      .select("*")
-      .eq("user_id", user.id)
-      .eq("status", "pending")
-      .order("expected_at", { ascending: true, nullsFirst: false });
-    if (program) q = q.eq("program", program);
+      .from('miles')
+      .select('*')
+      .eq('user_id', user.id)
+      .eq('status', 'pending')
+      .order('expected_at', { ascending: true, nullsFirst: false });
+    if (program) q = q.eq('program', program);
     const { data, error } = await q;
     if (error) toast.error(error.message);
     setRows(data ?? []);
@@ -122,13 +46,13 @@ export default function MilesPendingList({ program }: { program?: Program }) {
 
   async function markPosted(id: number) {
     const { error } = await supabase
-      .from("miles")
-      .update({ status: "posted", posted_at: new Date().toISOString() })
-      .eq("id", id);
+      .from('miles')
+      .update({ status: 'posted', posted_at: new Date().toISOString() })
+      .eq('id', id);
     if (error) {
       toast.error(error.message);
     } else {
-      toast.success("Milhas marcadas como creditadas");
+      toast.success('Milhas marcadas como creditadas');
       setRows((prev) => (prev ?? []).filter((r) => r.id !== id));
     }
   }
@@ -142,9 +66,9 @@ export default function MilesPendingList({ program }: { program?: Program }) {
     <Card className="p-4">
       <div className="mb-3 flex items-center justify-between">
         <div className="font-medium">
-          A receber {program ? `— ${program === "livelo" ? "Livelo" : program === "latampass" ? "LATAM Pass" : "Azul"}` : ""}
+          A receber {program ? `— ${BRANDS[program].label}` : ''}
         </div>
-        <div className="text-sm text-muted-foreground">Total: {total.toLocaleString("pt-BR")} pts</div>
+        <div className="text-sm text-muted-foreground">Total: {total.toLocaleString('pt-BR')} pts</div>
       </div>
       {loading ? (
         <div className="text-sm text-muted-foreground">Carregando…</div>
@@ -165,24 +89,22 @@ export default function MilesPendingList({ program }: { program?: Program }) {
             <tbody>
               {rows.map((r) => {
                 const d = r.expected_at ? dayjs(r.expected_at) : null;
-                const diff = d ? d.diff(dayjs(), "day") : null;
+                const diff = d ? d.diff(dayjs(), 'day') : null;
                 const diffLabel =
-                  diff === null ? "—" : diff === 0 ? "hoje" : diff > 0 ? `${diff}d` : `${diff}d`;
+                  diff === null ? '—' : diff === 0 ? 'hoje' : diff > 0 ? `${diff}d` : `${diff}d`;
                 const diffClass =
                   diff === null
-                    ? "text-muted-foreground"
+                    ? 'text-muted-foreground'
                     : diff < 0
-                    ? "text-red-500"
+                    ? 'text-red-500'
                     : diff <= 3
-                    ? "text-amber-500"
-                    : "text-emerald-500";
+                    ? 'text-amber-500'
+                    : 'text-emerald-500';
                 return (
                   <tr key={r.id} className="border-b last:border-none">
-                    <td className="py-2 capitalize">{r.program}</td>
-                    <td className="py-2 text-right">{r.amount.toLocaleString("pt-BR")}</td>
-                    <td className="py-2">
-                      {r.expected_at ? dayjs(r.expected_at).format("DD/MM/YYYY") : "—"}
-                    </td>
+                    <td className="py-2">{BRANDS[r.program].label}</td>
+                    <td className="py-2 text-right">{r.amount.toLocaleString('pt-BR')}</td>
+                    <td className="py-2">{r.expected_at ? dayjs(r.expected_at).format('DD/MM/YYYY') : '—'}</td>
                     <td className={`py-2 text-center font-medium ${diffClass}`}>{diffLabel}</td>
                     <td className="py-2 text-right">
                       <Button size="sm" onClick={() => markPosted(r.id)}>
@@ -199,4 +121,3 @@ export default function MilesPendingList({ program }: { program?: Program }) {
     </Card>
   );
 }
-

--- a/src/components/miles/brandConfig.tsx
+++ b/src/components/miles/brandConfig.tsx
@@ -1,0 +1,65 @@
+import React from 'react';
+
+export type MilesProgram = 'livelo' | 'latampass' | 'azul';
+
+export function LiveloLogo({ className = 'h-6 w-6' }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 64 64" className={className} aria-hidden>
+      <path d="M32 4c15 0 28 12 28 28S47 60 32 60 4 48 4 32 17 4 32 4Z" fill="#7A1FA2"/>
+      <path d="M20 35c0-7 5-13 12-13s12 6 12 13c0 4-2 7-5 9-4 3-10 3-14 0-3-2-5-5-5-9Z" fill="white"/>
+      <text x="32" y="39" textAnchor="middle" fontSize="12" fontWeight="700" fill="#7A1FA2">lv</text>
+    </svg>
+  );
+}
+
+export function LatamPassLogo({ className = 'h-6 w-6' }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 64 64" className={className} aria-hidden>
+      <rect rx="12" width="64" height="64" fill="#862633"/>
+      <path d="M12 36c12-6 20-10 40-12-10 6-18 12-24 20-6 1-10-1-16-8Z" fill="#E51C44"/>
+      <path d="M18 44c10-7 19-12 30-14-8 6-14 12-18 18" stroke="white" strokeWidth="2" fill="none"/>
+    </svg>
+  );
+}
+
+export function AzulLogo({ className = 'h-6 w-6' }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 64 64" className={className} aria-hidden>
+      <rect rx="12" width="64" height="64" fill="#1BA1E2"/>
+      <g fill="#0070AD">
+        <rect x="18" y="22" width="8" height="8" rx="1"/>
+        <rect x="28" y="22" width="8" height="8" rx="1"/>
+        <rect x="24" y="32" width="8" height="8" rx="1"/>
+        <rect x="34" y="32" width="8" height="8" rx="1"/>
+        <rect x="30" y="42" width="8" height="8" rx="1"/>
+      </g>
+    </svg>
+  );
+}
+
+export const BRANDS: Record<MilesProgram, { label: string; gradient: string; soft: string; softDark: string; Logo: (props: { className?: string }) => JSX.Element }> = {
+  livelo: {
+    label: 'Livelo',
+    gradient: 'from-[#7A1FA2] to-[#FF2D8D] dark:from-[#7A1FA2CC] dark:to-[#FF2D8D99]',
+    soft: '#F7F1FA',
+    softDark: '#7A1FA21A',
+    Logo: LiveloLogo,
+  },
+  latampass: {
+    label: 'LATAM Pass',
+    gradient: 'from-[#862633] to-[#E51C44] dark:from-[#862633CC] dark:to-[#E51C4499]',
+    soft: '#FBF2F4',
+    softDark: '#8626331A',
+    Logo: LatamPassLogo,
+  },
+  azul: {
+    label: 'Azul',
+    gradient: 'from-[#1BA1E2] to-[#0070AD] dark:from-[#1BA1E2CC] dark:to-[#0070AD99]',
+    soft: '#EEF8FF',
+    softDark: '#1BA1E21A',
+    Logo: AzulLogo,
+  },
+};
+
+export default BRANDS;
+

--- a/src/pages/MilhasLatam.tsx
+++ b/src/pages/MilhasLatam.tsx
@@ -2,6 +2,5 @@ import MilhasLivelo from './MilhasLivelo';
 
 export default function MilhasLatam() {
   // Reuso da página principal, alterando apenas o programa.
-  
-  return <MilhasLivelo program="latam" />;
+  return <MilhasLivelo program="latampass" />;
 }

--- a/src/pages/MilhasLivelo.tsx
+++ b/src/pages/MilhasLivelo.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from 'react';
 import dayjs from 'dayjs';
 import { toast } from 'sonner';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
+
 import MilesHeader, { type MilesProgram } from '@/components/MilesHeader';
 import PageHeader from '@/components/PageHeader';
 import { MotionCard } from '@/components/ui/MotionCard';
@@ -9,35 +10,12 @@ import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
 import { Button } from '@/components/ui/button';
 import ModalMilesMovement, { type MilesMovement } from '@/components/ModalMilesMovement';
 import MilesPendingList from '@/components/miles/MilesPendingList';
-import liveloLogo from '@/assets/logos/livelo.svg';
-import latamLogo from '@/assets/logos/latampass.svg';
-import azulLogo from '@/assets/logos/azul.svg';
+import { BRANDS } from '@/components/miles/brandConfig';
 
 import 'dayjs/locale/pt-br';
 dayjs.locale('pt-br');
 
 export default function MilhasLivelo({ program = 'livelo' }: { program?: MilesProgram }) {
-type Program = 'livelo' | 'latam' | 'azul';
-
-const CONFIG: Record<Program, { title: string; gradient: string; logo: string }> = {
-  livelo: {
-    title: 'Milhas — Livelo',
-    gradient: 'from-fuchsia-600 via-pink-500 to-rose-500',
-    logo: liveloLogo,
-  },
-  latam: {
-    title: 'Milhas — LATAM Pass',
-    gradient: 'from-red-600 via-rose-600 to-purple-600',
-    logo: latamLogo,
-  },
-  azul: {
-    title: 'Milhas — Azul',
-    gradient: 'from-sky-600 via-cyan-600 to-blue-600',
-    logo: azulLogo,
-  },
-};
-
-export default function MilhasLivelo({ program = 'livelo' }: { program?: Program }) {
   const [open, setOpen] = useState(false);
   const [edit, setEdit] = useState<MilesMovement | null>(null);
 
@@ -63,7 +41,7 @@ export default function MilhasLivelo({ program = 'livelo' }: { program?: Program
 
   const thisMonth = useMemo(() => dayjs().format('YYYY-MM'), []);
   const ganhosMes = useMemo(() => movs.filter(m=>m.kind==='earn'   && m.date.startsWith(thisMonth)).reduce((s,m)=>s+m.points,0), [movs, thisMonth]);
-  const resgMes  = useMemo(() => movs.filter(m=>m.kind==='redeem' && m.date.startsWith(thisMonth)).reduce((s,m)=>s+m.points,0), [movs, thisMonth]);
+  const resgMes  = useMemo(() => movs.filter(m=>m.kind==='redeem' && m.date.startsWith(thisMonth)).reduce((s,m)=>s+m.points,0),[movs, thisMonth]);
 
   const donut = useMemo(() => ([
     { name: 'Ganhos',   value: ganhosMes },
@@ -86,7 +64,7 @@ export default function MilhasLivelo({ program = 'livelo' }: { program?: Program
     toast.success('Excluído');
   };
 
-  const cfg = CONFIG[program];
+  const cfg = BRANDS[program];
 
   return (
     <div className="space-y-6">
@@ -95,10 +73,10 @@ export default function MilhasLivelo({ program = 'livelo' }: { program?: Program
       </MilesHeader>
       <MilesPendingList program={program} />
       <PageHeader
-        title={cfg.title}
+        title={`Milhas — ${cfg.label}`}
         subtitle="Saldo, a receber e expiração"
         gradient={cfg.gradient}
-        logoSrc={cfg.logo}
+        logo={<cfg.Logo className="h-8 w-8" />}
         actions={<Button onClick={()=>{ setEdit(null); setOpen(true); }}>Novo movimento</Button>}
       />
 


### PR DESCRIPTION
## Summary
- centralize miles partner data with hex palettes, dark-mode variants and inline SVG logos
- show partner gradients and logos in headers and badges
- extend PageHeader to accept a React logo while preserving logoSrc compatibility
- use shared brand labels in pending miles list

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_689d5cd244f083229ceb22173f6660f8