### PR TITLE
style(ui): polish hub cards, hero gradient and sidebar details

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -21,8 +21,8 @@ const PageHeader = (props: PageHeaderProps) => {
   return (
     <div
       className={cn(
-        "mb-6 rounded-xl text-white",
-        gradient ? `bg-gradient-to-r ${gradient}` : "bg-gradient-to-r from-emerald-900 to-teal-700"
+        "mb-6 rounded-xl text-white backdrop-blur-sm border-b border-white/10",
+        gradient ? `bg-gradient-to-r ${gradient}` : "bg-gradient-to-r from-emerald-600 to-teal-600"
       )}
     >
       <div className="container mx-auto px-4 py-5 flex items-center justify-between gap-4">

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -163,7 +163,7 @@ export function Sidebar() {
         ].join(" ")}
       >
         <div className="flex h-full flex-col">
-          <div className="m-2 flex items-center rounded-2xl sidebar-header p-4">
+          <div className="m-3 flex items-center rounded-2xl sidebar-header p-5 ring-1 ring-white/10">
             <Logo size="lg" />
             {!collapsed && <span className="ml-2 text-xl font-semibold">FY</span>}
             <div className="ml-auto flex items-center gap-2">
@@ -186,7 +186,7 @@ export function Sidebar() {
             </div>
           </div>
 
-          <nav ref={navRef} className="flex-1 overflow-y-auto px-2 py-4">
+          <nav ref={navRef} className="flex-1 overflow-y-auto scrollbar-none px-3 py-6">
             {sections.map((section) => (
               <div key={section.label} className="mt-4 first:mt-0">
                 {!collapsed && (

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -481,7 +481,7 @@ export default function Dashboard() {
 // ---------------------------------- partials
 function HeroHeader() {
   return (
-    <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-r from-emerald-600 via-teal-600 to-indigo-600 p-6 text-white shadow-lg">
+    <div className="relative overflow-hidden rounded-2xl bg-gradient-to-r from-emerald-600 to-teal-600 p-6 text-white backdrop-blur-sm border-b border-white/10 shadow-lg">
       {/* logo + título, sem descrição */}
       <div className="relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div className="flex items-center gap-3">
@@ -626,17 +626,17 @@ function CardFooterAction({ to, label }: { to: string; label: string }) {
 
 function QuickLink({ to, icon, title, desc }: { to: string; icon: ReactNode; title: string; desc: string }) {
   return (
-    <Card>
+    <Card className="group h-full border-0 bg-gradient-to-br from-emerald-500 to-teal-500 text-white shadow-[0_2px_12px_-3px_rgba(16,185,129,0.3)] transition hover:scale-[1.01]">
       <div className="mb-2 flex items-center gap-3">
-        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-emerald-500/15 text-emerald-600 ring-1 ring-emerald-500/30">
+        <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-white/20 text-white">
           {icon}
         </span>
         <span className="font-semibold">{title}</span>
       </div>
-      <div className="mb-4 text-sm text-zinc-500">{desc}</div>
+      <div className="mb-4 text-sm text-white/80">{desc}</div>
       <Link
         to={to}
-        className="inline-block rounded-lg bg-emerald-600/90 px-4 py-2 text-sm font-medium text-white shadow transition hover:bg-emerald-700"
+        className="inline-block rounded-lg bg-white/20 px-4 py-2 text-sm font-medium text-white transition hover:bg-white/30"
       >
         Abrir
       </Link>

--- a/src/pages/HomeOverview.tsx
+++ b/src/pages/HomeOverview.tsx
@@ -3,6 +3,7 @@ import { TrendingUp, Wallet, Target, Plane, Heart, ShoppingCart } from "lucide-r
 
 import PageHeader from "@/components/PageHeader";
 import { Card } from "@/components/ui/card";
+const hubCard = "group flex items-center gap-4 p-6 border-0 bg-gradient-to-br from-emerald-500 to-teal-500 text-white shadow-[0_2px_12px_-3px_rgba(16,185,129,0.3)] transition hover:scale-[1.01]";
 
 export default function HomeOverview() {
   return (
@@ -13,56 +14,56 @@ export default function HomeOverview() {
       />
       <div className="grid gap-6 md:grid-cols-2 xl:grid-cols-3">
         <Link to="/financas/resumo" className="block">
-          <Card className="p-6 flex items-center gap-4">
+          <Card className={hubCard}>
             <TrendingUp className="h-6 w-6" />
             <div>
               <div className="font-semibold">Finanças</div>
-              <div className="text-sm text-muted-foreground">Resumo mensal e anual</div>
+              <div className="text-sm text-white/80">Resumo mensal e anual</div>
             </div>
           </Card>
         </Link>
         <Link to="/investimentos" className="block">
-          <Card className="p-6 flex items-center gap-4">
+          <Card className={hubCard}>
             <Wallet className="h-6 w-6" />
             <div>
               <div className="font-semibold">Investimentos</div>
-              <div className="text-sm text-muted-foreground">Resumo e carteira</div>
+              <div className="text-sm text-white/80">Resumo e carteira</div>
             </div>
           </Card>
         </Link>
         <Link to="/metas" className="block">
-          <Card className="p-6 flex items-center gap-4">
+          <Card className={hubCard}>
             <Target className="h-6 w-6" />
             <div>
               <div className="font-semibold">Metas & Projetos</div>
-              <div className="text-sm text-muted-foreground">Progresso e aportes</div>
+              <div className="text-sm text-white/80">Progresso e aportes</div>
             </div>
           </Card>
         </Link>
         <Link to="/milhas" className="block">
-          <Card className="p-6 flex items-center gap-4">
+          <Card className={hubCard}>
             <Plane className="h-6 w-6" />
             <div>
               <div className="font-semibold">Milhas</div>
-              <div className="text-sm text-muted-foreground">Saldo, a receber e expiração</div>
+              <div className="text-sm text-white/80">Saldo, a receber e expiração</div>
             </div>
           </Card>
         </Link>
         <Link to="/lista-desejos" className="block">
-          <Card className="p-6 flex items-center gap-4">
+          <Card className={hubCard}>
             <Heart className="h-6 w-6" />
             <div>
               <div className="font-semibold">Lista de desejos</div>
-              <div className="text-sm text-muted-foreground">Planejamento de compras</div>
+              <div className="text-sm text-white/80">Planejamento de compras</div>
             </div>
           </Card>
         </Link>
         <Link to="/lista-compras" className="block">
-          <Card className="p-6 flex items-center gap-4">
+          <Card className={hubCard}>
             <ShoppingCart className="h-6 w-6" />
             <div>
               <div className="font-semibold">Lista de compras</div>
-              <div className="text-sm text-muted-foreground">Itens e orçamentos</div>
+              <div className="text-sm text-white/80">Itens e orçamentos</div>
             </div>
           </Card>
         </Link>


### PR DESCRIPTION
## Summary
- refresh hub cards with emerald gradient, subtle shadow and hover scale
- add blurred emerald→teal hero bar with bottom border
- widen sidebar padding, hide scrollbar and add header ring

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d651cbb808322b63f0d6f6226a01a