### PR TITLE
feat(milhas): show program names via BRANDS

### DIFF
--- a/src/components/miles/MilesPendingList.tsx
+++ b/src/components/miles/MilesPendingList.tsx
@@ -2,6 +2,7 @@ import dayjs from 'dayjs';
 import { useMemo } from 'react';
 
 import type { MilesProgram } from '@/components/miles/MilesHeader';
+import { BRAND_STYLE as BRANDS } from '@/components/BrandBadge';
 
 export type MilesPending = {
   id: string;
@@ -56,7 +57,7 @@ export default function MilesPendingList({ program }: { program?: MilesProgram }
           <tbody>
             {itens.map((m) => (
               <tr key={m.id} className="border-t">
-                {!program && <td className="py-2 capitalize">{m.program}</td>}
+                {!program && <td className="py-2">{BRANDS[m.program].label}</td>}
                 <td className="py-2">{m.partner}</td>
                 <td>{m.points}</td>
                 <td>{dayjs(m.expected_at).format('DD/MM/YYYY')}</td>


### PR DESCRIPTION
## Summary
- show full program names in pending list using BRANDS mapping

## Testing
- `npm test` *(fails: Missing script: test)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d661d556c83229247d70e28721131