### PR TITLE
Use BRANDS constant for MilhasLatam

### DIFF
--- a/src/lib/brands.ts
+++ b/src/lib/brands.ts
@@ -1,0 +1,7 @@
+export const BRANDS = {
+  livelo: 'livelo',
+  latam: 'latampass',
+  azul: 'azul',
+} as const;
+
+export type BrandProgram = (typeof BRANDS)[keyof typeof BRANDS];

--- a/src/pages/MilhasLatam.tsx
+++ b/src/pages/MilhasLatam.tsx
@@ -1,7 +1,8 @@
 import MilhasLivelo from './MilhasLivelo';
 
+import { BRANDS } from '@/lib/brands';
+
 export default function MilhasLatam() {
   // Reuso da página principal, alterando apenas o programa.
-
-  return <MilhasLivelo program="latampass" />;
+  return <MilhasLivelo program={BRANDS.latam} />;
 }


### PR DESCRIPTION
## Summary
- add BRANDS mapping for mileage program slugs
- use BRANDS.latam in MilhasLatam instead of hardcoded string

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d661fdb1083229b6ead5258109411