### PR TITLE
fix(milhas): add latam pass wrapper page

### DIFF
--- a/src/pages/MilhasLatam.tsx
+++ b/src/pages/MilhasLatam.tsx
@@ -1,7 +1,5 @@
-import MilhasLivelo from './MilhasLivelo';
+import MilhasLivelo from "./MilhasLivelo";
 
 export default function MilhasLatam() {
-  // Reuso da página principal, alterando apenas o programa.
-
   return <MilhasLivelo program="latampass" />;
 }


### PR DESCRIPTION
## Summary
- replace leftover conflict markers with MilhasLivelo wrapper for LATAM Pass page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d66c7e3208322a9b349048f96a0e9