### PR TITLE
refactor: remove conflict markers from livelo miles page

### DIFF
--- a/src/pages/MilhasLivelo.tsx
+++ b/src/pages/MilhasLivelo.tsx
@@ -13,7 +13,11 @@ import MilesPendingList from '@/components/miles/MilesPendingList';
 import 'dayjs/locale/pt-br';
 dayjs.locale('pt-br');
 
-export default function MilhasLivelo({ program = 'livelo' }: { program?: MilesProgram }) {
+interface MilhasLiveloProps {
+  program?: MilesProgram;
+}
+
+export default function MilhasLivelo({ program = 'livelo' }: MilhasLiveloProps) {
   const [open, setOpen] = useState(false);
   const [edit, setEdit] = useState<MilesMovement | null>(null);
 


### PR DESCRIPTION
## Summary
- add explicit props interface for Livelo miles page and keep optional `program` prop defaulting to livelo

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689d66c956bc83229bcc3c8ab8a05273