### PR TITLE
feat(milhas): show brand names in pending list

### DIFF
--- a/src/components/miles/MilesHeader.tsx
+++ b/src/components/miles/MilesHeader.tsx
@@ -6,19 +6,19 @@ import liveloLogo from '@/assets/logos/livelo.svg';
 
 export type MilesProgram = 'livelo' | 'latampass' | 'azul';
 
-const PROGRAM: Record<MilesProgram, { label: string; logo: string; gradient: string }> = {
+export const BRAND: Record<MilesProgram, { name: string; logo: string; gradient: string }> = {
   livelo: {
-    label: 'Livelo',
+    name: 'Livelo',
     logo: liveloLogo,
     gradient: 'from-fuchsia-600 via-pink-500 to-rose-500',
   },
   latampass: {
-    label: 'LATAM Pass',
+    name: 'LATAM Pass',
     logo: latamLogo,
     gradient: 'from-red-600 via-rose-600 to-purple-600',
   },
   azul: {
-    label: 'Azul',
+    name: 'Azul',
     logo: azulLogo,
     gradient: 'from-sky-600 via-cyan-600 to-blue-600',
   },
@@ -33,14 +33,14 @@ export default function MilesHeader({
   subtitle?: string;
   children?: ReactNode;
 }) {
-  const cfg = PROGRAM[program];
+  const cfg = BRAND[program];
   return (
     <header className={`mb-6 rounded-xl bg-gradient-to-r ${cfg.gradient} text-white`}>
       <div className="container mx-auto flex items-center justify-between gap-4 px-4 py-5">
         <div className="flex min-w-0 items-center gap-3">
-          <img src={cfg.logo} alt={cfg.label} className="h-7 w-auto shrink-0" />
+          <img src={cfg.logo} alt={cfg.name} className="h-7 w-auto shrink-0" />
           <div className="min-w-0">
-            <h1 className="text-xl font-semibold">Milhas — {cfg.label}</h1>
+            <h1 className="text-xl font-semibold">Milhas — {cfg.name}</h1>
             {subtitle ? (
               <p className="truncate text-sm leading-relaxed text-white/80">{subtitle}</p>
             ) : null}

--- a/src/components/miles/MilesPendingList.tsx
+++ b/src/components/miles/MilesPendingList.tsx
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { useMemo } from 'react';
 
-import type { MilesProgram } from '@/components/miles/MilesHeader';
+import { BRAND, type MilesProgram } from './MilesHeader';
 
 export type MilesPending = {
   id: string;
@@ -42,7 +42,9 @@ export default function MilesPendingList({ program }: { program?: MilesProgram }
 
   return (
     <div className="rounded-xl border bg-white p-4 dark:bg-slate-900">
-      <h3 className="mb-3 font-medium">A receber</h3>
+      <h3 className="mb-3 font-medium">
+        A receber{program ? ` — ${BRAND[program].name}` : ''}
+      </h3>
       <div className="overflow-x-auto">
         <table className="min-w-full text-sm">
           <thead className="text-left text-slate-500">
@@ -56,7 +58,7 @@ export default function MilesPendingList({ program }: { program?: MilesProgram }
           <tbody>
             {itens.map((m) => (
               <tr key={m.id} className="border-t">
-                {!program && <td className="py-2 capitalize">{m.program}</td>}
+                {!program && <td className="py-2">{BRAND[m.program].name}</td>}
                 <td className="py-2">{m.partner}</td>
                 <td>{m.points}</td>
                 <td>{dayjs(m.expected_at).format('DD/MM/YYYY')}</td>


### PR DESCRIPTION
## Summary
- use shared BRAND mapping to show program names in pending miles list
- expose BRAND info from MilesHeader

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d673fe6548322bd67c4940a6abfa0