### PR TITLE
refactor: highlight overview by route

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -309,7 +309,7 @@ function NavLeafLink({ leaf, collapsed }: { leaf: NavLeaf; collapsed?: boolean }
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/40",
           collapsed ? "justify-center" : "",
           isActive
-            ? leaf.label === "Visão geral"
+            ? leaf.to === "/dashboard"
               ? "sb-active bg-gradient-to-r from-emerald-600/20 to-emerald-400/20 text-emerald-200 ring-2 ring-emerald-400/60"
               : "sb-active bg-emerald-500/15 text-emerald-300 ring-1 ring-emerald-500/30"
             : "text-slate-300 hover:text-white hover:bg-emerald-600/10",


### PR DESCRIPTION
## Summary
- highlight overview link by route path instead of hard-coded label

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d6889ad2c8322a1ea3a958884bff6