### PR TITLE
fix: refine kpi arrows

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -588,14 +588,20 @@ function KpiCard({
             aria-hidden
             className="pointer-events-none mt-2 inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-1 text-xs font-medium text-emerald-700"
           >
-            ▲ bom
+            <span aria-hidden className="pointer-events-none opacity-25">
+              ▲
+            </span>
+            bom
           </span>
         ) : trend === "down" ? (
           <span
             aria-hidden
             className="pointer-events-none mt-2 inline-flex items-center gap-1 rounded-full bg-rose-100 px-2 py-1 text-xs font-medium text-rose-700"
           >
-            ▼ atenção
+            <span aria-hidden className="pointer-events-none opacity-25">
+              ▼
+            </span>
+            atenção
           </span>
         ) : null}
       </div>


### PR DESCRIPTION
## Summary
- ensure decorative KPI arrows are transparent to pointer events
- keep KPI content above decorative elements

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/pages/Dashboard.tsx`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d670c37508322905c7603997afd10