### PR TITLE
refactor: connect dashboard to live data

### DIFF
--- a/src/hooks/useMiles.ts
+++ b/src/hooks/useMiles.ts
@@ -1,0 +1,46 @@
+import { useEffect, useMemo, useState } from 'react';
+
+import { supabase } from '@/lib/supabaseClient';
+
+export type Mile = {
+  id: number;
+  program: string;
+  points: number;
+  date: string;
+  partner?: string | null;
+  expires_at?: string | null;
+  status?: string | null;
+  expected_at?: string | null;
+};
+
+export function useMiles() {
+  const [rows, setRows] = useState<Mile[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function fetchAll() {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data, error } = await supabase
+        .from('miles')
+        .select('*')
+        .order('date', { ascending: false });
+      if (error) throw error;
+      setRows((data as Mile[]) ?? []);
+    } catch (e: any) {
+      setError(e.message ?? String(e));
+      setRows([]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void fetchAll();
+  }, []);
+
+  const saldoTotal = useMemo(() => rows.reduce((s, r) => s + (r.points || 0), 0), [rows]);
+
+  return { rows, loading, error, saldoTotal, refetch: fetchAll } as const;
+}


### PR DESCRIPTION
## Summary
- replace dashboard mocks with `useTransactions`, `useInvestments`, `useGoals`, `useMiles`, and `getUpcoming`
- show upcoming bills, goals progress, and quick-links using live metrics
- add `useMiles` hook to fetch and aggregate miles data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689d688b6ddc8322962f65495a3ed9d4