### PR TITLE
feat: melhorias gerais e identidade visual

### DIFF
--- a/src/components/miles/MilesHeader.tsx
+++ b/src/components/miles/MilesHeader.tsx
@@ -1,27 +1,8 @@
 import type { ReactNode } from 'react';
 
-import { BRANDS, type MilesProgram } from './brandConfig';
+import BRANDS, { type MilesProgram } from './brandConfig';
 
 export type { MilesProgram } from './brandConfig';
-export type MilesProgram = 'livelo' | 'latampass' | 'azul';
-
-export const brandConfig: Record<MilesProgram, { label: string; logo: string; gradient: string }> = {
-  livelo: {
-    label: 'Livelo',
-    logo: liveloLogo,
-    gradient: 'from-fuchsia-600 via-pink-500 to-rose-500',
-  },
-  latampass: {
-    label: 'LATAM Pass',
-    logo: latamLogo,
-    gradient: 'from-red-600 via-rose-600 to-purple-600',
-  },
-  azul: {
-    label: 'Azul',
-    logo: azulLogo,
-    gradient: 'from-sky-600 via-cyan-600 to-blue-600',
-  },
-};
 
 export default function MilesHeader({
   program,
@@ -34,7 +15,6 @@ export default function MilesHeader({
 }) {
   const cfg = BRANDS[program];
   const Logo = cfg.Logo;
-  const cfg = brandConfig[program];
   return (
     <header className={`mb-6 rounded-xl bg-gradient-to-r ${cfg.gradient} text-white`}>
       <div className="container mx-auto flex items-center justify-between gap-4 px-4 py-5">

--- a/src/components/miles/MilesPendingList.tsx
+++ b/src/components/miles/MilesPendingList.tsx
@@ -2,8 +2,7 @@ import dayjs from 'dayjs';
 import { useCallback, useEffect, useState } from 'react';
 
 import { useAuth } from '@/contexts/AuthContext';
-import type { MilesProgram } from '@/components/miles/MilesHeader';
-import { BRAND_STYLE as BRANDS } from '@/components/BrandBadge';
+import BRANDS, { type MilesProgram } from '@/components/miles/brandConfig';
 
 export type MilesPending = {
   id: string;

--- a/src/components/miles/brandConfig.tsx
+++ b/src/components/miles/brandConfig.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import type { ReactElement } from "react";
 
 export type MilesProgram = 'livelo' | 'latampass' | 'azul';
 
@@ -37,7 +37,7 @@ export function AzulLogo({ className = "h-6 w-6" }: { className?: string }) {
   );
 }
 
-export const BRANDS: Record<MilesProgram, { label: string; gradient: string; soft: string; softDark: string; Logo: (props: { className?: string }) => JSX.Element }> = {
+export const BRANDS: Record<MilesProgram, { label: string; gradient: string; soft: string; softDark: string; Logo: (props: { className?: string }) => ReactElement }> = {
   livelo: {
     label: 'Livelo',
     gradient: 'from-[#7A1FA2] to-[#FF2D8D] dark:from-[#7A1FA2CC] dark:to-[#FF2D8D99]',

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -554,7 +554,7 @@ function KpiCard({
       {/* Ícone decorativo sem capturar cliques */}
       <div
         aria-hidden
-        className="pointer-events-none absolute -right-8 -top-8 z-0 h-28 w-28 rounded-full opacity-25 blur-2xl"
+        className="pointer-events-none absolute -right-8 -top-8 -z-10 h-28 w-28 rounded-full opacity-25 blur-2xl"
         style={{ background: `linear-gradient(135deg, ${colorFrom}, ${colorTo})` }}
       />
       <div className="relative z-10 flex flex-col">

--- a/src/pages/FinancasAnual.tsx
+++ b/src/pages/FinancasAnual.tsx
@@ -139,7 +139,7 @@ export default function FinancasAnual() {
               <TrendingUp size={18} />
             </div>
             <div className="flex flex-col">
-              <span className="text-sm text-slate-500 dark:text-slate-300">Entradas</span>
+              <span className="text-sm text-slate-500 dark:text-slate-200">Entradas</span>
               <AnimatedNumber value={kpis.income} />
             </div>
           </div>
@@ -151,7 +151,7 @@ export default function FinancasAnual() {
               <TrendingDown size={18} />
             </div>
             <div className="flex flex-col">
-              <span className="text-sm text-slate-500 dark:text-slate-300">Saídas</span>
+              <span className="text-sm text-slate-500 dark:text-slate-200">Saídas</span>
               <AnimatedNumber value={kpis.expense} />
             </div>
           </div>
@@ -163,7 +163,7 @@ export default function FinancasAnual() {
               <Coins size={18} />
             </div>
             <div className="flex flex-col">
-              <span className="text-sm text-slate-500 dark:text-slate-300">Saldo</span>
+              <span className="text-sm text-slate-500 dark:text-slate-200">Saldo</span>
               <AnimatedNumber value={kpis.balance} />
             </div>
           </div>
@@ -175,9 +175,9 @@ export default function FinancasAnual() {
               <CalendarRange size={18} />
             </div>
             <div className="flex flex-col">
-              <span className="text-sm text-slate-500 dark:text-slate-300">Mês com maior despesa</span>
+              <span className="text-sm text-slate-500 dark:text-slate-200">Mês com maior despesa</span>
               <AnimatedNumber value={worstMonth?.expense || 0} />
-              <span className="text-xs text-slate-500 dark:text-slate-300">{worstLabel || '—'}</span>
+              <span className="text-xs text-slate-500 dark:text-slate-200">{worstLabel || '—'}</span>
             </div>
           </div>
         </MotionCard>


### PR DESCRIPTION
## Summary
- fix z-index on dashboard decorative elements
- improve dark mode contrast on annual finances
- clean up miles brand configuration and pending list

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: process stuck during `vite build` transform stage)*

------
https://chatgpt.com/codex/tasks/task_e_689d6b15c5548322a1ce049ade6b3584