### PR TITLE
feat: add monthly miles summary

### DIFF
--- a/src/components/miles/MilesMonthlyTotals.tsx
+++ b/src/components/miles/MilesMonthlyTotals.tsx
@@ -1,0 +1,44 @@
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import BRANDS, { type MilesProgram } from "@/components/miles/brandConfig";
+
+interface MonthlyTotal {
+  program: MilesProgram;
+  total: number;
+}
+
+// Placeholder data; replace with real values later
+const MOCK_MONTHLY_TOTALS: MonthlyTotal[] = [
+  { program: "livelo", total: 1500 },
+  { program: "latampass", total: 2300 },
+  { program: "azul", total: 900 },
+];
+
+export default function MilesMonthlyTotals() {
+  return (
+    <Card className="transition-shadow hover:shadow-lg">
+      <CardHeader className="pb-1">
+        <CardTitle className="text-base">A receber no mês</CardTitle>
+      </CardHeader>
+      <CardContent className="pt-2">
+        <div className="overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead className="text-left text-muted-foreground">
+              <tr>
+                <th className="py-2">Programa</th>
+                <th className="py-2 text-right">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {MOCK_MONTHLY_TOTALS.map((m) => (
+                <tr key={m.program} className="border-t">
+                  <td className="py-2">{BRANDS[m.program].label}</td>
+                  <td className="py-2 text-right">{m.total.toLocaleString("pt-BR")} pts</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/pages/MilhasHome.tsx
+++ b/src/pages/MilhasHome.tsx
@@ -4,6 +4,7 @@ import { Plane } from 'lucide-react';
 import PageHeader from '@/components/PageHeader';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent } from '@/components/ui/card';
 import MilesPendingList from '@/components/miles/MilesPendingList';
+import MilesMonthlyTotals from '@/components/miles/MilesMonthlyTotals';
 
 export default function MilhasHome() {
   const saldoTotal = 12000;
@@ -47,6 +48,8 @@ export default function MilhasHome() {
           </CardContent>
         </Card>
       </div>
+
+      <MilesMonthlyTotals />
 
       <MilesPendingList />
 


### PR DESCRIPTION
## Summary
- show "A receber no mês" card with placeholder totals by program
- include Livelo, LATAM Pass, and Azul entries

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689de25b65308322ad39da99393af483