### PR TITLE
feat: add lists summary card

### DIFF
--- a/src/components/ListsSummaryCard.tsx
+++ b/src/components/ListsSummaryCard.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Progress } from '@/components/ui/progress';
+import { Skeleton } from '@/components/ui/Skeleton';
+import { getListsSummary } from '@/data/lists';
+
+interface SummaryData {
+  wishlistCount: number;
+  shoppingCount: number;
+  completedPercent: number;
+}
+
+export default function ListsSummaryCard() {
+  const [data, setData] = useState<SummaryData | null>(null);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setData(getListsSummary());
+    }, 600);
+
+    return () => clearTimeout(timer);
+  }, []);
+
+  return (
+    <Card className="p-4 space-y-4">
+      <div className="flex items-center justify-between">
+        <span className="font-semibold">Listas</span>
+        {data ? (
+          <Badge variant="secondary">{data.completedPercent}%</Badge>
+        ) : (
+          <Skeleton className="h-5 w-12" />
+        )}
+      </div>
+      <div className="space-y-2 text-sm">
+        <div className="flex items-center justify-between">
+          <span>Desejos</span>
+          {data ? (
+            <Badge variant="outline">{data.wishlistCount}</Badge>
+          ) : (
+            <Skeleton className="h-5 w-6" />
+          )}
+        </div>
+        <div className="flex items-center justify-between">
+          <span>Compras</span>
+          {data ? (
+            <Badge variant="outline">{data.shoppingCount}</Badge>
+          ) : (
+            <Skeleton className="h-5 w-6" />
+          )}
+        </div>
+        {data ? (
+          <Progress value={data.completedPercent} className="h-2" />
+        ) : (
+          <Skeleton className="h-2 w-full" />
+        )}
+      </div>
+    </Card>
+  );
+}
+

--- a/src/data/lists.ts
+++ b/src/data/lists.ts
@@ -1,0 +1,29 @@
+export interface ListItem {
+  id: number;
+  title: string;
+  completed: boolean;
+}
+
+export const wishlist: ListItem[] = [
+  { id: 1, title: 'Smartwatch', completed: false },
+  { id: 2, title: 'Notebook', completed: false },
+  { id: 3, title: 'Fone de ouvido', completed: true },
+];
+
+export const shoppingList: ListItem[] = [
+  { id: 1, title: 'Leite', completed: true },
+  { id: 2, title: 'Arroz', completed: false },
+  { id: 3, title: 'Pão', completed: false },
+  { id: 4, title: 'Café', completed: true },
+];
+
+export function getListsSummary() {
+  const wishlistCount = wishlist.length;
+  const shoppingCount = shoppingList.length;
+  const completed = shoppingList.filter((item) => item.completed).length;
+  const completedPercent = shoppingCount
+    ? Math.round((completed / shoppingCount) * 100)
+    : 0;
+
+  return { wishlistCount, shoppingCount, completedPercent };
+}

--- a/src/pages/HomeOverview.tsx
+++ b/src/pages/HomeOverview.tsx
@@ -3,6 +3,7 @@ import { TrendingUp, Wallet, Target, Plane, Heart, ShoppingCart } from "lucide-r
 
 import PageHeader from "@/components/PageHeader";
 import { Card } from "@/components/ui/card";
+import ListsSummaryCard from "@/components/ListsSummaryCard";
 const hubCard = "group flex items-center gap-4 p-6 border-0 bg-gradient-to-br from-emerald-500 to-teal-500 text-white shadow-[0_2px_12px_-3px_rgba(16,185,129,0.3)] transition hover:scale-[1.01]";
 
 export default function HomeOverview() {
@@ -68,6 +69,7 @@ export default function HomeOverview() {
           </Card>
         </Link>
       </div>
+      <ListsSummaryCard />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- create ListsSummaryCard component with skeletons, badges and progress bar
- add mock list data and summary helper
- show list summary card on home overview page

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689de25c43248322aeabf39f3467096a