### PR TITLE
refactor: extract miles brand logos

### DIFF
--- a/src/components/miles/BrandLogos.tsx
+++ b/src/components/miles/BrandLogos.tsx
@@ -1,0 +1,19 @@
+import liveloLogo from "@/assets/logos/livelo.svg";
+import latamPassLogo from "@/assets/logos/latampass.svg";
+import azulLogo from "@/assets/logos/azul.svg";
+
+export type LogoProps = {
+  className?: string;
+};
+
+export function LiveloLogo({ className = "h-6 w-6" }: LogoProps) {
+  return <img src={liveloLogo} alt="" className={className} aria-hidden />;
+}
+
+export function LatamPassLogo({ className = "h-6 w-6" }: LogoProps) {
+  return <img src={latamPassLogo} alt="" className={className} aria-hidden />;
+}
+
+export function AzulLogo({ className = "h-6 w-6" }: LogoProps) {
+  return <img src={azulLogo} alt="" className={className} aria-hidden />;
+}

--- a/src/components/miles/brandConfig.tsx
+++ b/src/components/miles/brandConfig.tsx
@@ -1,41 +1,8 @@
 import type { ReactElement } from "react";
 
+import { LiveloLogo, LatamPassLogo, AzulLogo } from "./BrandLogos";
+
 export type MilesProgram = 'livelo' | 'latampass' | 'azul';
-
-export function LiveloLogo({ className = "h-6 w-6" }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 64 64" className={className} aria-hidden>
-      <path d="M32 4c15 0 28 12 28 28S47 60 32 60 4 48 4 32 17 4 32 4Z" fill="#7A1FA2"/>
-      <path d="M20 35c0-7 5-13 12-13s12 6 12 13c0 4-2 7-5 9-4 3-10 3-14 0-3-2-5-5-5-9Z" fill="white"/>
-      <text x="32" y="39" textAnchor="middle" fontSize="12" fontWeight="700" fill="#7A1FA2">lv</text>
-    </svg>
-  );
-}
-
-export function LatamPassLogo({ className = "h-6 w-6" }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 64 64" className={className} aria-hidden>
-      <rect rx="12" width="64" height="64" fill="#862633"/>
-      <path d="M12 36c12-6 20-10 40-12-10 6-18 12-24 20-6 1-10-1-16-8Z" fill="#E51C44"/>
-      <path d="M18 44c10-7 19-12 30-14-8 6-14 12-18 18" stroke="white" strokeWidth="2" fill="none"/>
-    </svg>
-  );
-}
-
-export function AzulLogo({ className = "h-6 w-6" }: { className?: string }) {
-  return (
-    <svg viewBox="0 0 64 64" className={className} aria-hidden>
-      <rect rx="12" width="64" height="64" fill="#1BA1E2"/>
-      <g fill="#0070AD">
-        <rect x="18" y="22" width="8" height="8" rx="1"/>
-        <rect x="28" y="22" width="8" height="8" rx="1"/>
-        <rect x="24" y="32" width="8" height="8" rx="1"/>
-        <rect x="34" y="32" width="8" height="8" rx="1"/>
-        <rect x="30" y="42" width="8" height="8" rx="1"/>
-      </g>
-    </svg>
-  );
-}
 
 export const BRANDS: Record<MilesProgram, { label: string; gradient: string; soft: string; softDark: string; Logo: (props: { className?: string }) => ReactElement }> = {
   livelo: {


### PR DESCRIPTION
## Summary
- refactor miles brand configuration to use shared logo components
- add dedicated BrandLogos components that load existing SVG assets

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689de787d7308322ba37640360bf74e3