### PR TITLE
refactor: inline MilhasLatam program for LATAM

### DIFF
--- a/src/pages/MilhasLatam.tsx
+++ b/src/pages/MilhasLatam.tsx
@@ -1,8 +1,6 @@
 import MilhasLivelo from './MilhasLivelo';
 
-import { BRANDS } from '@/lib/brands';
-
 export default function MilhasLatam() {
   // Reuso da página principal, alterando apenas o programa.
-  return <MilhasLivelo program={BRANDS.latam} />;
+  return <MilhasLivelo program="latampass" />;
 }


### PR DESCRIPTION
## Summary
- remove BRANDS import in MilhasLatam
- inline <MilhasLivelo program="latampass" /> in default export

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689de78ae9808322b957586f73a4c83c