### PR TITLE
feat: add KPI strip component to dashboard

### DIFF
--- a/src/components/dashboard/KPIStrip.tsx
+++ b/src/components/dashboard/KPIStrip.tsx
@@ -1,0 +1,37 @@
+import type { LucideIcon } from "lucide-react";
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+export interface KPIMetric {
+  icon: LucideIcon;
+  label: string;
+  value: string | number;
+  comparison: string;
+  tooltip: string;
+}
+
+export default function KPIStrip({ metrics }: { metrics: KPIMetric[] }) {
+  return (
+    <TooltipProvider>
+      <div className="overflow-x-auto">
+        <div className="flex gap-4 pb-2">
+          {metrics.map((m) => (
+            <Tooltip key={m.label}>
+              <TooltipTrigger asChild>
+                <div className="min-w-[180px] shrink-0 rounded-lg border bg-card p-4 shadow-sm">
+                  <div className="mb-2 flex items-center gap-2 text-muted-foreground">
+                    <m.icon className="h-4 w-4" />
+                    <span className="text-xs font-medium">{m.label}</span>
+                  </div>
+                  <div className="text-lg font-semibold leading-none">{m.value}</div>
+                  <div className="mt-1 text-xs text-muted-foreground">{m.comparison}</div>
+                </div>
+              </TooltipTrigger>
+              <TooltipContent>{m.tooltip}</TooltipContent>
+            </Tooltip>
+          ))}
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState, type ReactNode, type PropsWithChildren } from 'react';
 import { Link } from "react-router-dom";
-import { motion, useMotionValue, animate } from "framer-motion";
+import { motion } from "framer-motion";
 import {
   ResponsiveContainer,
   ComposedChart,
@@ -34,6 +34,7 @@ import { Skeleton } from "@/components/ui/Skeleton";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { formatCurrency } from "@/lib/utils";
 import MetasSummary from "@/components/MetasSummary";
+import KPIStrip from "@/components/dashboard/KPIStrip";
 
 // Garantir decorativos não interativos
 // className nos decorativos: "pointer-events-none select-none -z-10 opacity-25"
@@ -44,53 +45,55 @@ function monthShortPtBR(n: number) {
   return arr[Math.max(1, Math.min(12, n)) - 1];
 }
 
-// CountUp (framer-motion)
-function CountUp({ value }: { value: number }) {
-  const mv = useMotionValue(0);
-  const [out, setOut] = useState(0);
-  useEffect(() => {
-    const ctrl = animate(mv, value, { duration: 1.1, ease: "easeOut" });
-    const unsub = mv.on("change", (v) => setOut(v));
-    return () => {
-      ctrl.stop();
-      unsub();
-    };
-  }, [value, mv]);
-  return <span>{formatCurrency(Math.round(out))}</span>;
-}
-
-// Sparkline inline SVG
-function Sparkline({ data, color = "#10b981" }: { data: number[]; color?: string }) {
-  const w = 88, h = 28, pad = 2;
-  const max = Math.max(...data);
-  const min = Math.min(...data);
-  const norm = (v: number) => (max === min ? 0.5 : (v - min) / (max - min));
-  const pts = data.map((v, i) => {
-    const x = (i / (data.length - 1)) * (w - pad * 2) + pad;
-    const y = h - (norm(v) * (h - pad * 2) + pad);
-    return `${x.toFixed(2)},${y.toFixed(2)}`;
-  });
-  const path = `M ${pts.join(" L ")}`;
-  const last = pts[pts.length - 1]?.split(",") || ["0", "0"];
-  return (
-    <svg width={w} height={h} viewBox={`0 0 ${w} ${h}`} className="overflow-visible">
-      <defs>
-        <linearGradient id="sparkFill" x1="0" x2="0" y1="0" y2="1">
-          <stop offset="0%" stopColor={color} stopOpacity="0.45" />
-          <stop offset="100%" stopColor={color} stopOpacity="0" />
-        </linearGradient>
-      </defs>
-      <path d={`${path} L ${w - pad},${h - pad} L ${pad},${h - pad} Z`} fill="url(#sparkFill)" />
-      <path d={path} stroke={color} strokeWidth={2} fill="none" strokeLinecap="round" />
-      <circle cx={Number(last[0])} cy={Number(last[1])} r={2.2} fill={color} />
-    </svg>
-  );
-}
 
 // ---------------------------------- page
 export default function Dashboard() {
   // MOCKs – depois plugamos hooks reais
   const kpis = { saldoMes: 7532, entradasMes: 12400, saidasMes: 4868, investidoTotal: 36250 };
+  const mockData = [
+    {
+      icon: Wallet,
+      label: "Saldo do mês",
+      value: formatCurrency(kpis.saldoMes),
+      comparison: "+12% vs mês anterior",
+      tooltip: "Saldo total após entradas e saídas do mês.",
+    },
+    {
+      icon: TrendingUp,
+      label: "Entradas",
+      value: formatCurrency(kpis.entradasMes),
+      comparison: "+8% vs mês anterior",
+      tooltip: "Entradas de dinheiro no mês.",
+    },
+    {
+      icon: CreditCard,
+      label: "Saídas",
+      value: formatCurrency(kpis.saidasMes),
+      comparison: "-5% vs mês anterior",
+      tooltip: "Saídas de dinheiro no mês.",
+    },
+    {
+      icon: PiggyBank,
+      label: "Investido total",
+      value: formatCurrency(kpis.investidoTotal),
+      comparison: "+2% vs mês anterior",
+      tooltip: "Total aplicado em investimentos.",
+    },
+    {
+      icon: Landmark,
+      label: "Patrimônio líquido",
+      value: formatCurrency(94850),
+      comparison: "+4% vs mês anterior",
+      tooltip: "Valor total dos ativos menos passivos.",
+    },
+    {
+      icon: Plane,
+      label: "Milhas",
+      value: "45k",
+      comparison: "+3% vs mês anterior",
+      tooltip: "Milhas acumuladas em programas de fidelidade.",
+    },
+  ];
 
   const base = [
     { m: "Jan", in: 3600, out: 1900 },
@@ -116,18 +119,6 @@ export default function Dashboard() {
   // eslint-disable-next-line react-hooks/exhaustive-deps -- base is static
   []);
 
-  const sparkIn = base.slice(-8).map((d) => d.in);
-  const sparkOut = base.slice(-8).map((d) => d.out);
-  const sparkSaldo = fluxo.slice(-8).map((d) => d.saldo);
-  const sparkInv = useMemo(() => {
-    let inv = 30000;
-    return base.slice(-8).map((d) => {
-      inv += Math.max(0, d.in - d.out) * 0.35;
-      return inv;
-    });
-  },
-  // eslint-disable-next-line react-hooks/exhaustive-deps -- base is static
-  []);
 
   const carteira = [
     { name: "Renda fixa", value: 14800 },
@@ -198,53 +189,8 @@ export default function Dashboard() {
       </motion.div>
 
       {/* KPIs --------------------------------------------------- */}
-      <motion.div className="grid items-stretch gap-4 md:grid-cols-2 xl:grid-cols-4" variants={container}>
-        <motion.div variants={item}>
-          <KpiCard
-            title="Saldo do mês"
-            icon={<Wallet className="size-5" />}
-            colorFrom="hsl(var(--chart-emerald))"
-            colorTo="hsl(var(--chart-emerald)/.7)"
-            value={kpis.saldoMes}
-            spark={sparkSaldo}
-            sparkColor="hsl(var(--chart-emerald))"
-          />
-        </motion.div>
-        <motion.div variants={item}>
-          <KpiCard
-            title="Entradas"
-            icon={<TrendingUp className="size-5" />}
-            colorFrom="hsl(var(--chart-blue))"
-            colorTo="hsl(var(--chart-blue)/.7)"
-            value={kpis.entradasMes}
-            trend="up"
-            spark={sparkIn}
-            sparkColor="hsl(var(--chart-blue))"
-          />
-        </motion.div>
-        <motion.div variants={item}>
-          <KpiCard
-            title="Saídas"
-            icon={<CreditCard className="size-5" />}
-            colorFrom="hsl(var(--chart-rose))"
-            colorTo="hsl(var(--chart-amber))"
-            value={kpis.saidasMes}
-            trend="down"
-            spark={sparkOut}
-            sparkColor="hsl(var(--chart-rose))"
-          />
-        </motion.div>
-        <motion.div variants={item}>
-          <KpiCard
-            title="Investido total"
-            icon={<PiggyBank className="size-5" />}
-            colorFrom="hsl(var(--chart-violet))"
-            colorTo="hsl(var(--chart-blue))"
-            value={kpis.investidoTotal}
-            spark={sparkInv}
-            sparkColor="hsl(var(--chart-violet))"
-          />
-        </motion.div>
+      <motion.div variants={item}>
+        <KPIStrip metrics={mockData} />
       </motion.div>
 
       {/* GRÁFICOS ---------------------------------------------- */}
@@ -507,83 +453,6 @@ function LogoFY({ size = 44 }: { size?: number }) {
         <path d="M34 0l-6 9 6 9h-8l-4-6-4 6h-8l6-9-6-9h8l4 6 4-6z" />
       </g>
     </svg>
-  );
-}
-
-function KpiCard({
-  title,
-  icon,
-  value,
-  trend,
-  colorFrom,
-  colorTo,
-  spark,
-  sparkColor,
-}: {
-  title: string;
-  icon: ReactNode;
-  value: number;
-  trend?: "up" | "down";
-  colorFrom: string;
-  colorTo: string;
-  spark: number[];
-  sparkColor: string;
-}) {
-  return (
-    <motion.div
-      whileHover={{ y: -2 }}
-      transition={{ type: "spring", stiffness: 220, damping: 18 }}
-      className="kpi relative h-[136px]"
-    >
-      {/* Ícone decorativo sem capturar cliques */}
-      <div
-        aria-hidden
-        className="pointer-events-none absolute -right-8 -top-8 -z-10 h-28 w-28 rounded-full opacity-25 blur-2xl"
-        style={{ background: `linear-gradient(135deg, ${colorFrom}, ${colorTo})` }}
-      />
-      <div className="relative z-10 flex flex-col">
-        <div className="flex items-start justify-between gap-3">
-          <div className="flex items-center gap-2">
-            <div
-              className="kpi-icon"
-              style={{ background: `linear-gradient(135deg, ${colorFrom}, ${colorTo})` }}
-            >
-              {icon}
-            </div>
-            <div>
-              <p className="kpi-title">{title}</p>
-              <p className="kpi-value">
-                <CountUp value={value} />
-              </p>
-            </div>
-          </div>
-          <div className="shrink-0">
-            <Sparkline data={spark} color={sparkColor} />
-          </div>
-        </div>
-        {trend === "up" ? (
-          <span
-            aria-hidden
-            className="pointer-events-none mt-2 inline-flex items-center gap-1 rounded-full bg-emerald-100 px-2 py-1 text-xs font-medium text-emerald-700"
-          >
-            <span aria-hidden className="pointer-events-none opacity-25">
-              ▲
-            </span>
-            bom
-          </span>
-        ) : trend === "down" ? (
-          <span
-            aria-hidden
-            className="pointer-events-none mt-2 inline-flex items-center gap-1 rounded-full bg-rose-100 px-2 py-1 text-xs font-medium text-rose-700"
-          >
-            <span aria-hidden className="pointer-events-none opacity-25">
-              ▼
-            </span>
-            atenção
-          </span>
-        ) : null}
-      </div>
-    </motion.div>
   );
 }
 


### PR DESCRIPTION
## Summary
- create KPI strip component rendering horizontal KPI cards with tooltips
- integrate KPI strip into dashboard and remove old KPI grid

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689df44e9d5083229154d661b561ae03