### PR TITLE
Add vibrant theme colors and motion effects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "dayjs": "^1.11.13",
         "framer-motion": "^12.23.12",
         "lucide-react": "^0.539.0",
+        "phosphor-react": "^1.4.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.62.0",
@@ -8846,6 +8847,18 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/phosphor-react": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/phosphor-react/-/phosphor-react-1.4.1.tgz",
+      "integrity": "sha512-gO5j7U0xZrdglTAYDYPACU4xDOFBTJmptrrB/GeR+tHhCZF3nUMyGmV/0hnloKjuTrOmpSFlbfOY78H39rgjUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "dayjs": "^1.11.13",
     "framer-motion": "^12.23.12",
     "lucide-react": "^0.539.0",
+    "phosphor-react": "^1.4.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.62.0",

--- a/src/components/FilterBar.tsx
+++ b/src/components/FilterBar.tsx
@@ -1,6 +1,7 @@
 // src/components/FilterBar.tsx
 import { useCallback, type KeyboardEvent } from 'react';
-import { CalendarRange, Calendar } from "lucide-react";
+import { CalendarBlank, Calendar } from 'phosphor-react'
+import { motion } from 'framer-motion'
 
 import { usePeriod } from "@/state/periodFilter";
 import {
@@ -72,12 +73,15 @@ export default function FilterBar({ variant = "default", className = "" }: Props
   const gap = variant === "compact" ? "gap-2 sm:gap-2.5" : "gap-2 sm:gap-3";
 
   return (
-    <div
+    <motion.div
       className={`card-surface ${pad} ${gap} mx-auto flex w-full max-w-xl flex-wrap items-center justify-center ${className}`}
       aria-label="Filtro de período"
       role="group"
       onKeyDown={onKeyDown}
       tabIndex={0}
+      initial={{ opacity: 0, y: -8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
     >
       {/* Toggle Mensal/Anual */}
       <div className="inline-flex overflow-hidden rounded-xl border border-white/30 bg-white/70 backdrop-blur shadow-sm dark:border-white/10 dark:bg-zinc-900/50">
@@ -109,7 +113,7 @@ export default function FilterBar({ variant = "default", className = "" }: Props
       {mode === "monthly" && (
         <div className="inline-flex items-center gap-2">
           <span className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10">
-            <CalendarRange className="h-4 w-4 text-emerald-600" />
+            <CalendarBlank size={16} className="h-4 w-4 text-emerald-600" />
           </span>
           {/* Nunca usar "" como value controlado */}
           <Select value={String(month)} onValueChange={(v) => setMonth(Number(v))}>
@@ -130,7 +134,7 @@ export default function FilterBar({ variant = "default", className = "" }: Props
       {/* Seletor de ano (premium) */}
       <div className="inline-flex items-center gap-2">
         <span className="inline-flex h-9 w-9 items-center justify-center rounded-xl bg-white/70 backdrop-blur border border-white/30 shadow-sm dark:bg-zinc-900/50 dark:border-white/10">
-          <Calendar className="h-4 w-4 text-emerald-600" />
+          <Calendar size={16} className="h-4 w-4 text-emerald-600" />
         </span>
         {/* Nunca passe "" como value */}
         <Select value={String(year)} onValueChange={(v) => setYear(Number(v))}>
@@ -146,6 +150,6 @@ export default function FilterBar({ variant = "default", className = "" }: Props
           </SelectContent>
         </Select>
       </div>
-    </div>
+    </motion.div>
   );
 }

--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -1,5 +1,6 @@
 // src/components/PageHeader.tsx
 import type { ReactNode } from "react";
+import { motion } from 'framer-motion'
 
 import { cn } from "@/lib/utils";
 
@@ -19,11 +20,14 @@ export type PageHeaderProps = {
 const PageHeader = (props: PageHeaderProps) => {
   const { title, subtitle, icon, actions, breadcrumbs, children, gradient, logoSrc } = props;
   return (
-    <div
+    <motion.div
       className={cn(
         "mb-6 rounded-xl text-white backdrop-blur-sm border-b border-white/10",
         gradient ? `bg-gradient-to-r ${gradient}` : "bg-gradient-to-r from-emerald-600 to-teal-600"
       )}
+      initial={{ opacity: 0, y: -10 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.25 }}
     >
       <div className="container mx-auto px-4 py-5 flex items-center justify-between gap-4">
         <div className="flex items-center gap-3 min-w-0">
@@ -61,7 +65,7 @@ const PageHeader = (props: PageHeaderProps) => {
       </div>
 
       {children ? <div className="container mx-auto px-4 pb-4">{children}</div> : null}
-    </div>
+    </motion.div>
   );
 };
 

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { cva, type VariantProps } from "class-variance-authority"
+import { motion } from 'framer-motion'
 
 import { cn } from "@/lib/utils"
 
@@ -42,11 +43,24 @@ export interface ButtonProps
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : "button"
+    if (asChild) {
+      return (
+        <Slot
+          ref={ref as any}
+          className={cn(buttonVariants({ variant, size, className }))}
+          {...props}
+        />
+      )
+    }
+
     return (
-      <Comp
+      <motion.button
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
+        whileHover={{ scale: 1.03 }}
+        whileTap={{ scale: 0.97 }}
+        initial={{ opacity: 0, y: -4 }}
+        animate={{ opacity: 1, y: 0 }}
         {...props}
       />
     )

--- a/src/index.css
+++ b/src/index.css
@@ -141,7 +141,7 @@
     font-family: var(--font-sans);
   }
   body {
-    @apply bg-background text-foreground antialiased;
+    @apply bg-background text-foreground antialiased font-sans;
   }
   h1,
   h2,

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
+import '@fontsource-variable/inter'
 
 import App from '@/App'
 import AppErrorBoundary from '@/components/AppErrorBoundary'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -8,15 +8,15 @@ export default {
   		center: true
   	},
   	extend: {
-  		colors: {
-  			fy: {
-  				bg: '#014D46',
-  				primary: '#009579',
-  				coral: '#FF4F5A',
-  				amber: '#F6BE23',
-  				blue: '#1E88E5',
-  				surface: '#FFFFFF'
-  			},
+                colors: {
+                        fy: {
+                                bg: '#014D46',
+                                primary: '#009579',
+                                coral: '#FF4F5A',
+                                amber: '#F6BE23',
+                                blue: '#1E88E5',
+                                surface: '#FFFFFF'
+                        },
   			background: 'hsl(var(--background))',
   			foreground: 'hsl(var(--foreground))',
   			card: {
@@ -50,14 +50,21 @@ export default {
   			border: 'hsl(var(--border))',
   			input: 'hsl(var(--input))',
   			ring: 'hsl(var(--ring))',
-  			chart: {
-  				'1': 'hsl(var(--chart-1))',
-  				'2': 'hsl(var(--chart-2))',
-  				'3': 'hsl(var(--chart-3))',
-  				'4': 'hsl(var(--chart-4))',
-  				'5': 'hsl(var(--chart-5))'
-  			}
-  		},
+                        chart: {
+                                '1': 'hsl(var(--chart-1))',
+                                '2': 'hsl(var(--chart-2))',
+                                '3': 'hsl(var(--chart-3))',
+                                '4': 'hsl(var(--chart-4))',
+                                '5': 'hsl(var(--chart-5))'
+                        },
+                        vibrant: {
+                                pink: '#FF007F',
+                                orange: '#FF8A00',
+                                cyan: '#00E5FF',
+                                lime: '#7FFF00',
+                                purple: '#9D00FF'
+                        }
+                },
   		fontFamily: {
   			sans: [
   				'Inter',
@@ -107,5 +114,21 @@ export default {
   		}
   	}
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [
+        require("tailwindcss-animate"),
+        function({ addUtilities }) {
+                addUtilities({
+                        '.glass': {
+                                'background-color': 'rgba(255,255,255,0.7)',
+                                'backdrop-filter': 'blur(12px)',
+                                'border': '1px solid rgba(255,255,255,0.4)',
+                                'box-shadow': '0 1px 2px rgba(0,0,0,0.05)'
+                        },
+                        '.dark .glass': {
+                                'background-color': 'rgba(255,255,255,0.05)',
+                                'border': '1px solid rgba(255,255,255,0.1)'
+                        }
+                });
+        }
+  ],
 }


### PR DESCRIPTION
## Summary
- extend Tailwind with vibrant palette and glassmorphic utilities
- load Inter font globally and apply to base styles
- adopt phosphor-react icons and framer‑motion animations for buttons and headers

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689df45163948322b2dbbcb340d3f3b4