### PR TITLE
feat: add glass card utility and header alpha variable

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -40,6 +40,8 @@
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.05);
   --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.1);
   --shadow-card: 0 8px 20px rgba(0, 0, 0, 0.08);
+  /* Header gradient opacity */
+  --header-alpha: 1;
 }
 
 /* Preferência de tema */
@@ -237,6 +239,9 @@ body::after {
   }
   .kpi-value {
     @apply text-2xl sm:text-3xl font-semibold tracking-tight;
+  }
+  .glass-card {
+    @apply bg-white/60 dark:bg-gray-900/40 backdrop-blur-xl border border-white/20 dark:border-white/10 shadow-[0_8px_30px_rgb(0,0,0,0.12)];
   }
 }
 


### PR DESCRIPTION
## Summary
- add global `--header-alpha` variable for adjustable header gradient opacity
- introduce `glass-card` Tailwind utility for frosted cards

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Parsing error in Dashboard.tsx)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689df9fa9bc08322aab2bcab57d1085c