### PR TITLE
fix: update investment breadcrumb base link

### DIFF
--- a/src/pages/CarteiraBolsa.tsx
+++ b/src/pages/CarteiraBolsa.tsx
@@ -69,7 +69,7 @@ export default function CarteiraBolsa() {
         title="Carteira — Bolsa"
         subtitle="Lançamentos e aportes desta classe."
         icon={<CandlestickChart className="h-5 w-5" />}
-        breadcrumbs={[{ label: "Investimentos", href: "/investimentos" }, { label: "Carteira", href: "/investimentos/bolsa" }, { label: "Bolsa" }]}
+        breadcrumbs={[{ label: "Investimentos", href: "/investimentos/resumo" }, { label: "Carteira", href: "/investimentos/bolsa" }, { label: "Bolsa" }]}
         actions={<Button className="gap-2" onClick={() => setOpenNew(true)}><Plus className="h-4 w-4" /> Novo investimento</Button>}
       />
 

--- a/src/pages/CarteiraCripto.tsx
+++ b/src/pages/CarteiraCripto.tsx
@@ -69,7 +69,7 @@ export default function CarteiraCripto() {
         title="Carteira — Cripto"
         subtitle="Lançamentos e aportes desta classe."
         icon={<Coins className="h-5 w-5" />}
-        breadcrumbs={[{ label: "Investimentos", href: "/investimentos" }, { label: "Carteira", href: "/investimentos/cripto" }, { label: "Cripto" }]}
+        breadcrumbs={[{ label: "Investimentos", href: "/investimentos/resumo" }, { label: "Carteira", href: "/investimentos/cripto" }, { label: "Cripto" }]}
         actions={<Button className="gap-2" onClick={() => setOpenNew(true)}><Plus className="h-4 w-4" /> Novo investimento</Button>}
       />
 

--- a/src/pages/CarteiraFIIs.tsx
+++ b/src/pages/CarteiraFIIs.tsx
@@ -69,7 +69,7 @@ export default function CarteiraFIIs() {
         title="Carteira — FIIs"
         subtitle="Lançamentos e aportes desta classe."
         icon={<Building2 className="h-5 w-5" />}
-        breadcrumbs={[{ label: "Investimentos", href: "/investimentos" }, { label: "Carteira", href: "/investimentos/fiis" }, { label: "FIIs" }]}
+        breadcrumbs={[{ label: "Investimentos", href: "/investimentos/resumo" }, { label: "Carteira", href: "/investimentos/fiis" }, { label: "FIIs" }]}
         actions={<Button className="gap-2" onClick={() => setOpenNew(true)}><Plus className="h-4 w-4" /> Novo investimento</Button>}
       />
 

--- a/src/pages/CarteiraRendaFixa.tsx
+++ b/src/pages/CarteiraRendaFixa.tsx
@@ -70,7 +70,7 @@ export default function CarteiraRendaFixa() {
         title="Carteira — Renda Fixa"
         subtitle="Lançamentos e aportes desta classe."
         icon={<Coins className="h-5 w-5" />}
-        breadcrumbs={[{ label: "Investimentos", href: "/investimentos" }, { label: "Carteira", href: "/investimentos/renda-fixa" }, { label: "Renda Fixa" }]}
+        breadcrumbs={[{ label: "Investimentos", href: "/investimentos/resumo" }, { label: "Carteira", href: "/investimentos/renda-fixa" }, { label: "Renda Fixa" }]}
         actions={<Button className="gap-2" onClick={() => setOpenNew(true)}><Plus className="h-4 w-4" /> Novo investimento</Button>}
       />
 

--- a/src/pages/Investimentos.tsx
+++ b/src/pages/Investimentos.tsx
@@ -85,7 +85,7 @@ export default function InvestimentosResumo() {
         title="Investimentos — Resumo"
         subtitle="Visão geral dos seus aportes por classe de ativos. Crie e edite nas páginas de Carteira."
         icon={<PieIcon className="h-5 w-5" />}
-        breadcrumbs={[{ label: "Investimentos", href: "/investimentos" }, { label: "Resumo" }]}
+        breadcrumbs={[{ label: "Investimentos", href: "/investimentos/resumo" }, { label: "Resumo" }]}
       />
 
       {/* KPIs */}


### PR DESCRIPTION
## Summary
- fix breadcrumbs for investment pages to point base to `/investimentos/resumo`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Parsing error in src/pages/Dashboard.tsx)*
- `npx eslint src/pages/Investimentos.tsx src/pages/CarteiraRendaFixa.tsx src/pages/CarteiraFIIs.tsx src/pages/CarteiraBolsa.tsx src/pages/CarteiraCripto.tsx`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689dfbe4b0bc8322892fdcb6a6291259