### PR TITLE
feat(financas): add finance widgets and stories

### DIFF
--- a/src/components/financas/AlertasList.stories.tsx
+++ b/src/components/financas/AlertasList.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import AlertasList from './AlertasList';
+
+const meta: Meta<typeof AlertasList> = {
+  title: 'Components/Financas/AlertasList',
+  component: AlertasList,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof AlertasList>;
+
+export const Default: Story = {
+  args: {
+    alertas: [
+      { id: '1', mensagem: 'Saldo baixo na conta corrente' },
+      { id: '2', mensagem: 'Cartão de crédito próximo do limite' },
+    ],
+    onViewDetails: () => alert('detalhes'),
+  },
+};

--- a/src/components/financas/AlertasList.tsx
+++ b/src/components/financas/AlertasList.tsx
@@ -1,0 +1,34 @@
+import { EmptyState } from '@/components/ui/EmptyState';
+
+export type Alerta = {
+  id: string;
+  mensagem: string;
+};
+
+export type AlertasListProps = {
+  alertas: Alerta[];
+  onViewDetails: () => void;
+};
+
+export default function AlertasList({ alertas, onViewDetails }: AlertasListProps) {
+  return (
+    <div className="card-surface p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="font-medium">Alertas</h3>
+        <button onClick={onViewDetails} className="text-sm text-emerald-700 hover:underline">
+          Ver detalhes
+        </button>
+      </div>
+      {alertas.length === 0 ? (
+        <EmptyState title="Sem alertas" />
+      ) : (
+        <ul className="list-disc pl-5 text-sm space-y-1">
+          {alertas.map((a) => (
+            <li key={a.id}>{a.mensagem}</li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/financas/DespesasPorCategoriaChart.stories.tsx
+++ b/src/components/financas/DespesasPorCategoriaChart.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import DespesasPorCategoriaChart from './DespesasPorCategoriaChart';
+
+const meta: Meta<typeof DespesasPorCategoriaChart> = {
+  title: 'Components/Financas/DespesasPorCategoriaChart',
+  component: DespesasPorCategoriaChart,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof DespesasPorCategoriaChart>;
+
+export const Default: Story = {
+  args: {
+    data: [
+      { categoria: 'Moradia', valor: 800 },
+      { categoria: 'Transporte', valor: 300 },
+      { categoria: 'Lazer', valor: 200 },
+    ],
+    onViewDetails: () => alert('detalhes'),
+  },
+};

--- a/src/components/financas/DespesasPorCategoriaChart.tsx
+++ b/src/components/financas/DespesasPorCategoriaChart.tsx
@@ -1,0 +1,54 @@
+import { PieChart, Pie, Cell, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+import { formatCurrency } from '@/lib/utils';
+import { EmptyState } from '@/components/ui/EmptyState';
+
+export type DespesaCategoria = {
+  categoria: string;
+  valor: number;
+};
+
+export type DespesasPorCategoriaChartProps = {
+  data: DespesaCategoria[];
+  onViewDetails: () => void;
+};
+
+const COLORS = ['#10b981', '#3b82f6', '#f59e0b', '#ef4444', '#6366f1', '#8b5cf6'];
+
+export default function DespesasPorCategoriaChart({ data, onViewDetails }: DespesasPorCategoriaChartProps) {
+  return (
+    <div className="card-surface p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="font-medium">Despesas por categoria</h3>
+        <button onClick={onViewDetails} className="text-sm text-emerald-700 hover:underline">
+          Ver detalhes
+        </button>
+      </div>
+      <div className="h-64">
+        {data.length === 0 ? (
+          <EmptyState title="Sem dados" />
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <PieChart>
+              <Pie
+                data={data}
+                dataKey="valor"
+                nameKey="categoria"
+                innerRadius={70}
+                outerRadius={100}
+                paddingAngle={2}
+              >
+                {data.map((entry, index) => (
+                  <Cell key={entry.categoria} fill={COLORS[index % COLORS.length]} />
+                ))}
+              </Pie>
+              <Tooltip formatter={(v: number) => formatCurrency(v)} />
+              <Legend />
+            </PieChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/financas/EntradasVsSaidasChart.stories.tsx
+++ b/src/components/financas/EntradasVsSaidasChart.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import EntradasVsSaidasChart from './EntradasVsSaidasChart';
+
+const meta: Meta<typeof EntradasVsSaidasChart> = {
+  title: 'Components/Financas/EntradasVsSaidasChart',
+  component: EntradasVsSaidasChart,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof EntradasVsSaidasChart>;
+
+export const Default: Story = {
+  args: {
+    data: [
+      { mes: 'Jan', entradas: 2000, saidas: 1500 },
+      { mes: 'Fev', entradas: 1800, saidas: 1900 },
+      { mes: 'Mar', entradas: 2200, saidas: 1700 },
+    ],
+    onViewDetails: () => alert('detalhes'),
+  },
+};

--- a/src/components/financas/EntradasVsSaidasChart.tsx
+++ b/src/components/financas/EntradasVsSaidasChart.tsx
@@ -1,0 +1,45 @@
+import { BarChart, Bar, XAxis, YAxis, Tooltip, Legend, ResponsiveContainer } from 'recharts';
+
+import { formatCurrency } from '@/lib/utils';
+import { EmptyState } from '@/components/ui/EmptyState';
+
+export type EntradasVsSaidasPoint = {
+  mes: string;
+  entradas: number;
+  saidas: number;
+};
+
+export type EntradasVsSaidasChartProps = {
+  data: EntradasVsSaidasPoint[];
+  onViewDetails: () => void;
+};
+
+export default function EntradasVsSaidasChart({ data, onViewDetails }: EntradasVsSaidasChartProps) {
+  return (
+    <div className="card-surface p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="font-medium">Entradas vs Saídas</h3>
+        <button onClick={onViewDetails} className="text-sm text-emerald-700 hover:underline">
+          Ver detalhes
+        </button>
+      </div>
+      <div className="h-64">
+        {data.length === 0 ? (
+          <EmptyState title="Sem dados" />
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart data={data} margin={{ top: 16, right: 24, bottom: 8, left: 8 }}>
+              <XAxis dataKey="mes" />
+              <YAxis tickFormatter={(v) => formatCurrency(Number(v))} width={80} />
+              <Tooltip formatter={(v: number) => formatCurrency(v)} />
+              <Legend />
+              <Bar dataKey="entradas" fill="#10b981" />
+              <Bar dataKey="saidas" fill="#ef4444" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/financas/FluxoMensalChart.stories.tsx
+++ b/src/components/financas/FluxoMensalChart.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import FluxoMensalChart from './FluxoMensalChart';
+
+const meta: Meta<typeof FluxoMensalChart> = {
+  title: 'Components/Financas/FluxoMensalChart',
+  component: FluxoMensalChart,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof FluxoMensalChart>;
+
+export const Default: Story = {
+  args: {
+    data: [
+      { mes: 'Jan', valor: 1000 },
+      { mes: 'Fev', valor: 500 },
+      { mes: 'Mar', valor: 1500 },
+    ],
+    onViewDetails: () => alert('detalhes'),
+  },
+};

--- a/src/components/financas/FluxoMensalChart.tsx
+++ b/src/components/financas/FluxoMensalChart.tsx
@@ -1,0 +1,42 @@
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from 'recharts';
+
+import { formatCurrency } from '@/lib/utils';
+import { EmptyState } from '@/components/ui/EmptyState';
+
+export type FluxoMensalPoint = {
+  mes: string;
+  valor: number;
+};
+
+export type FluxoMensalChartProps = {
+  data: FluxoMensalPoint[];
+  onViewDetails: () => void;
+};
+
+export default function FluxoMensalChart({ data, onViewDetails }: FluxoMensalChartProps) {
+  return (
+    <div className="card-surface p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="font-medium">Fluxo mensal</h3>
+        <button onClick={onViewDetails} className="text-sm text-emerald-700 hover:underline">
+          Ver detalhes
+        </button>
+      </div>
+      <div className="h-64">
+        {data.length === 0 ? (
+          <EmptyState title="Sem dados" />
+        ) : (
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={data} margin={{ top: 16, right: 24, bottom: 8, left: 8 }}>
+              <XAxis dataKey="mes" />
+              <YAxis tickFormatter={(v) => formatCurrency(Number(v))} width={80} />
+              <Tooltip formatter={(v: number) => formatCurrency(v)} />
+              <Line type="monotone" dataKey="valor" stroke="#10b981" strokeWidth={2} dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+    </div>
+  );
+}
+

--- a/src/components/financas/LancamentosRecentesTable.stories.tsx
+++ b/src/components/financas/LancamentosRecentesTable.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import LancamentosRecentesTable from './LancamentosRecentesTable';
+
+const meta: Meta<typeof LancamentosRecentesTable> = {
+  title: 'Components/Financas/LancamentosRecentesTable',
+  component: LancamentosRecentesTable,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof LancamentosRecentesTable>;
+
+export const Default: Story = {
+  args: {
+    lancamentos: [
+      { id: '1', descricao: 'Salário', data: '2025-06-01', valor: 3000 },
+      { id: '2', descricao: 'Supermercado', data: '2025-06-05', valor: -200 },
+    ],
+    onViewDetails: () => alert('detalhes'),
+  },
+};

--- a/src/components/financas/LancamentosRecentesTable.tsx
+++ b/src/components/financas/LancamentosRecentesTable.tsx
@@ -1,0 +1,52 @@
+import { formatCurrency } from '@/lib/utils';
+import { EmptyState } from '@/components/ui/EmptyState';
+
+export type Lancamento = {
+  id: string;
+  descricao: string;
+  data: string;
+  valor: number;
+};
+
+export type LancamentosRecentesTableProps = {
+  lancamentos: Lancamento[];
+  onViewDetails: () => void;
+};
+
+export default function LancamentosRecentesTable({ lancamentos, onViewDetails }: LancamentosRecentesTableProps) {
+  return (
+    <div className="card-surface p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="font-medium">Lançamentos recentes</h3>
+        <button onClick={onViewDetails} className="text-sm text-emerald-700 hover:underline">
+          Ver detalhes
+        </button>
+      </div>
+      {lancamentos.length === 0 ? (
+        <EmptyState title="Sem lançamentos" />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="text-left">
+                <th className="py-2">Descrição</th>
+                <th className="py-2">Data</th>
+                <th className="py-2 text-right">Valor</th>
+              </tr>
+            </thead>
+            <tbody>
+              {lancamentos.map((l) => (
+                <tr key={l.id} className="border-t border-zinc-100/60 dark:border-zinc-800/60">
+                  <td className="py-2">{l.descricao}</td>
+                  <td className="py-2">{new Date(l.data).toLocaleDateString('pt-BR')}</td>
+                  <td className="py-2 text-right font-medium">{formatCurrency(l.valor)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/financas/OrcamentoProgress.stories.tsx
+++ b/src/components/financas/OrcamentoProgress.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import OrcamentoProgress from './OrcamentoProgress';
+
+const meta: Meta<typeof OrcamentoProgress> = {
+  title: 'Components/Financas/OrcamentoProgress',
+  component: OrcamentoProgress,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof OrcamentoProgress>;
+
+export const Default: Story = {
+  args: {
+    orcamentos: [
+      { categoria: 'Alimentação', usado: 400, limite: 600 },
+      { categoria: 'Lazer', usado: 150, limite: 300 },
+    ],
+    onViewDetails: () => alert('detalhes'),
+  },
+};

--- a/src/components/financas/OrcamentoProgress.tsx
+++ b/src/components/financas/OrcamentoProgress.tsx
@@ -1,0 +1,48 @@
+import { formatCurrency } from '@/lib/utils';
+import { EmptyState } from '@/components/ui/EmptyState';
+import { Progress } from '@/components/ui/progress';
+
+export type OrcamentoItem = {
+  categoria: string;
+  usado: number;
+  limite: number;
+};
+
+export type OrcamentoProgressProps = {
+  orcamentos: OrcamentoItem[];
+  onViewDetails: () => void;
+};
+
+export default function OrcamentoProgress({ orcamentos, onViewDetails }: OrcamentoProgressProps) {
+  return (
+    <div className="card-surface p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="font-medium">Orçamento</h3>
+        <button onClick={onViewDetails} className="text-sm text-emerald-700 hover:underline">
+          Ver detalhes
+        </button>
+      </div>
+      {orcamentos.length === 0 ? (
+        <EmptyState title="Sem orçamento" />
+      ) : (
+        <ul className="space-y-4">
+          {orcamentos.map((o) => {
+            const percent = Math.min(100, (o.usado / o.limite) * 100);
+            return (
+              <li key={o.categoria}>
+                <div className="mb-1 flex justify-between text-sm">
+                  <span>{o.categoria}</span>
+                  <span>
+                    {formatCurrency(o.usado)} / {formatCurrency(o.limite)}
+                  </span>
+                </div>
+                <Progress value={percent} className="h-2" />
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/financas/ProximasContasList.stories.tsx
+++ b/src/components/financas/ProximasContasList.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+
+import ProximasContasList from './ProximasContasList';
+
+const meta: Meta<typeof ProximasContasList> = {
+  title: 'Components/Financas/ProximasContasList',
+  component: ProximasContasList,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ProximasContasList>;
+
+export const Default: Story = {
+  args: {
+    contas: [
+      { nome: 'Aluguel', vencimento: '2025-06-10', valor: 1200 },
+      { nome: 'Internet', vencimento: '2025-06-15', valor: 100 },
+    ],
+    onViewDetails: () => alert('detalhes'),
+  },
+};

--- a/src/components/financas/ProximasContasList.tsx
+++ b/src/components/financas/ProximasContasList.tsx
@@ -1,0 +1,40 @@
+import { formatCurrency } from '@/lib/utils';
+import { EmptyState } from '@/components/ui/EmptyState';
+
+export type ContaPagar = {
+  nome: string;
+  vencimento: string;
+  valor: number;
+};
+
+export type ProximasContasListProps = {
+  contas: ContaPagar[];
+  onViewDetails: () => void;
+};
+
+export default function ProximasContasList({ contas, onViewDetails }: ProximasContasListProps) {
+  return (
+    <div className="card-surface p-4">
+      <div className="mb-2 flex items-center justify-between">
+        <h3 className="font-medium">Próximas contas</h3>
+        <button onClick={onViewDetails} className="text-sm text-emerald-700 hover:underline">
+          Ver detalhes
+        </button>
+      </div>
+      {contas.length === 0 ? (
+        <EmptyState title="Nenhuma conta" />
+      ) : (
+        <ul className="divide-y divide-zinc-100/60 dark:divide-zinc-800/60 text-sm">
+          {contas.map((c) => (
+            <li key={c.nome + c.vencimento} className="flex items-center justify-between py-2">
+              <span className="truncate">{c.nome}</span>
+              <span>{new Date(c.vencimento).toLocaleDateString('pt-BR')}</span>
+              <span className="font-medium">{formatCurrency(c.valor)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+

--- a/src/components/financas/index.ts
+++ b/src/components/financas/index.ts
@@ -1,0 +1,20 @@
+export { default as FluxoMensalChart } from './FluxoMensalChart';
+export type { FluxoMensalPoint, FluxoMensalChartProps } from './FluxoMensalChart';
+
+export { default as EntradasVsSaidasChart } from './EntradasVsSaidasChart';
+export type { EntradasVsSaidasPoint, EntradasVsSaidasChartProps } from './EntradasVsSaidasChart';
+
+export { default as DespesasPorCategoriaChart } from './DespesasPorCategoriaChart';
+export type { DespesaCategoria, DespesasPorCategoriaChartProps } from './DespesasPorCategoriaChart';
+
+export { default as ProximasContasList } from './ProximasContasList';
+export type { ContaPagar, ProximasContasListProps } from './ProximasContasList';
+
+export { default as LancamentosRecentesTable } from './LancamentosRecentesTable';
+export type { Lancamento, LancamentosRecentesTableProps } from './LancamentosRecentesTable';
+
+export { default as OrcamentoProgress } from './OrcamentoProgress';
+export type { OrcamentoItem, OrcamentoProgressProps } from './OrcamentoProgress';
+
+export { default as AlertasList } from './AlertasList';
+export type { Alerta, AlertasListProps } from './AlertasList';


### PR DESCRIPTION
## Summary
- add financial widgets (charts, lists, progress) with data props and detail callbacks
- export financas components for reuse
- provide basic Storybook stories for visual tests

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e08a983dc8322b23ec768a941f5e0