### PR TITLE
style: glass card blur and dark charts

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -241,7 +241,7 @@ body::after {
     @apply text-2xl sm:text-3xl font-semibold tracking-tight;
   }
   .glass-card {
-    @apply bg-white/60 dark:bg-gray-900/40 backdrop-blur-xl border border-white/20 dark:border-white/10 shadow-[0_8px_30px_rgb(0,0,0,0.12)];
+    @apply bg-white/60 dark:bg-gray-950/60 backdrop-blur-xl border border-white/20 dark:border-white/10 shadow-[0_8px_30px_rgba(0,0,0,0.12)] dark:shadow-[0_8px_30px_rgba(0,0,0,0.4)];
   }
 }
 

--- a/src/lib/palette.ts
+++ b/src/lib/palette.ts
@@ -32,8 +32,8 @@ export const CATEGORY_COLORS: Record<string, string> = {
 };
 
 export const SERIES_COLORS = {
-  income:  '#3b82f6', // blue-500
-  expense: '#ef4444', // red-500
+  income:  'hsl(var(--chart-blue))',
+  expense: 'hsl(var(--chart-rose))',
 };
 
 // Map category name or id to a deterministic color

--- a/src/pages/Investments.tsx
+++ b/src/pages/Investments.tsx
@@ -29,7 +29,13 @@ type Investment = {
   note: string | null;
   created_at: string;
 };
-const COLORS = ["#0ea5e9", "#10b981", "#6366f1", "#f59e0b", "#ef4444"];
+const COLORS = [
+  "hsl(var(--chart-blue))",
+  "hsl(var(--chart-emerald))",
+  "hsl(var(--chart-violet))",
+  "hsl(var(--chart-amber))",
+  "hsl(var(--chart-rose))",
+];
 const BRL = (v: number | null | undefined) =>
   (v ?? 0).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
 const monthKey = (d: string | Date) => {
@@ -114,6 +120,7 @@ export default function InvestmentsResumo() {
         title="Investimentos"
         subtitle="Acompanhe seus aportes e a distribuição por classe. (Resumo geral)"
         icon={<PieIcon className="h-5 w-5" />}
+        gradient="from-emerald-600 to-teal-600"
       />
 
       {/* Filtros topo */}
@@ -136,17 +143,17 @@ export default function InvestmentsResumo() {
 
       {/* KPIs */}
       <div className="mt-6 grid gap-4 md:grid-cols-3">
-        <Card className="shadow-sm">
+        <Card className="glass-card">
           <CardHeader className="pb-2"><CardDescription>Total investido</CardDescription>
             <CardTitle className="text-2xl">{BRL(kpis.invested)}</CardTitle>
           </CardHeader>
         </Card>
-        <Card className="shadow-sm">
+        <Card className="glass-card">
           <CardHeader className="pb-2"><CardDescription>Operações no período</CardDescription>
             <CardTitle className="text-2xl">{kpis.ops}</CardTitle>
           </CardHeader>
         </Card>
-        <Card className="shadow-sm">
+        <Card className="glass-card">
           <CardHeader className="pb-2"><CardDescription>Ativos diferentes</CardDescription>
             <CardTitle className="text-2xl">{kpis.ativos}</CardTitle>
           </CardHeader>
@@ -155,7 +162,7 @@ export default function InvestmentsResumo() {
 
       {/* Gráficos */}
       <div className="mt-6 grid gap-4 lg:grid-cols-2">
-        <Card className="shadow-sm">
+        <Card className="glass-card">
           <CardHeader><CardTitle>Distribuição por classe</CardTitle></CardHeader>
           <CardContent className="h-[300px]">
             {byType.length === 0 ? (
@@ -174,7 +181,7 @@ export default function InvestmentsResumo() {
           </CardContent>
         </Card>
 
-        <Card className="shadow-sm">
+        <Card className="glass-card">
           <CardHeader><CardTitle>Aportes nos últimos 12 meses</CardTitle></CardHeader>
           <CardContent className="h-[300px]">
             <ResponsiveContainer width="100%" height="100%">
@@ -183,7 +190,7 @@ export default function InvestmentsResumo() {
                 <XAxis dataKey="month" tickMargin={8} />
                 <YAxis tickFormatter={(v) => (v / 1000).toFixed(0) + "k"} />
                 <Tooltip formatter={(v: unknown) => BRL(Number(v))} />
-                <Bar dataKey="valor" radius={[6, 6, 0, 0]} />
+                <Bar dataKey="valor" fill="hsl(var(--chart-blue))" radius={[6, 6, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
           </CardContent>
@@ -191,7 +198,7 @@ export default function InvestmentsResumo() {
       </div>
 
       {!loading && items.length === 0 && (
-        <Card className="mt-6 p-6">
+        <Card className="glass-card mt-6 p-6">
           <CardTitle className="text-base">Nenhum dado ainda</CardTitle>
           <CardDescription>Cadastre seus aportes nas páginas de Carteira (Renda fixa, FIIs, Ações, Cripto).</CardDescription>
         </Card>


### PR DESCRIPTION
## Summary
- add teal-to-emerald gradient header and glass card styling to Investments page
- theme Recharts with CSS variable palette for dark mode
- adjust glass-card utility for stronger dark contrast

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e08ac153c8322809d978a9edc1912