### PR TITLE
feat: add reusable placeholders for empty widgets

### DIFF
--- a/src/components/MetasSummary.tsx
+++ b/src/components/MetasSummary.tsx
@@ -1,12 +1,23 @@
 import { motion } from "framer-motion";
+import { Target } from "lucide-react";
 
 import { useGoals } from "@/hooks/useGoals";
+import { EmptyState } from "@/components/ui/EmptyState";
 
 export default function MetasSummary() {
   const { data } = useGoals();
   const topGoals = [...data]
     .sort((a, b) => (b.progress_pct || 0) - (a.progress_pct || 0))
     .slice(0, 3);
+  if (topGoals.length === 0) {
+    return (
+      <EmptyState
+        icon={<Target className="h-6 w-6" />}
+        title="Nenhuma meta"
+        action={{ label: "Criar meta", href: "/metas" }}
+      />
+    );
+  }
 
   return (
     <div className="space-y-4">

--- a/src/components/dashboard/AlertList.tsx
+++ b/src/components/dashboard/AlertList.tsx
@@ -13,7 +13,13 @@ export type AlertItem = {
 // Renders a list of upcoming payments/alerts.
 export default function AlertList({ items }: { items: AlertItem[] }) {
   if (items.length === 0) {
-    return <EmptyState icon={<CreditCard className="h-6 w-6" />} title="Nenhuma conta a vencer" />;
+    return (
+      <EmptyState
+        icon={<CreditCard className="h-6 w-6" />}
+        title="Nenhuma conta a vencer"
+        action={{ label: 'Adicionar', href: '/financas/mensal' }}
+      />
+    );
   }
   return (
     <ul className="divide-y divide-zinc-100/60 dark:divide-zinc-800/60">

--- a/src/components/dashboard/AlertsWidget.tsx
+++ b/src/components/dashboard/AlertsWidget.tsx
@@ -1,0 +1,26 @@
+import { Bell } from "lucide-react";
+
+import { WidgetCard, WidgetHeader } from "./WidgetCard";
+
+import { EmptyState } from "@/components/ui/EmptyState";
+
+interface AlertMessage {
+  message: string;
+}
+
+export default function AlertsWidget({ alerts, ...rest }: { alerts: AlertMessage[]; onClick?: () => void }) {
+  return (
+    <WidgetCard {...rest}>
+      <WidgetHeader title="Alertas" />
+      {alerts.length === 0 ? (
+        <EmptyState icon={<Bell className="h-6 w-6" />} title="Nenhum alerta" />
+      ) : (
+        <ul className="space-y-1 text-sm">
+          {alerts.map((a, i) => (
+            <li key={i}>{a.message}</li>
+          ))}
+        </ul>
+      )}
+    </WidgetCard>
+  );
+}

--- a/src/components/dashboard/RecurrenceList.tsx
+++ b/src/components/dashboard/RecurrenceList.tsx
@@ -1,5 +1,8 @@
-import WidgetCard from './WidgetCard';
+import { Repeat } from 'lucide-react';
 
+import WidgetCard, { WidgetHeader } from './WidgetCard';
+
+import { EmptyState } from '@/components/ui/EmptyState';
 import { formatCurrency } from '@/lib/utils';
 
 interface RecurrenceItem {
@@ -14,15 +17,24 @@ interface RecurrenceListProps {
 
 export default function RecurrenceList({ items, ...rest }: RecurrenceListProps) {
   return (
-    <WidgetCard title="Despesas fixas" {...rest}>
-      <ul className="space-y-1 text-sm">
-        {items.map((r) => (
-          <li key={r.name} className="flex justify-between">
-            <span>{r.name}</span>
-            <span className="font-medium">{formatCurrency(r.amount)}</span>
-          </li>
-        ))}
-      </ul>
+    <WidgetCard {...rest}>
+      <WidgetHeader title="Despesas fixas" />
+      {items.length === 0 ? (
+        <EmptyState
+          icon={<Repeat className="h-6 w-6" />}
+          title="Nenhuma despesa fixa"
+          action={{ label: 'Adicionar', href: '/financas/mensal' }}
+        />
+      ) : (
+        <ul className="space-y-1 text-sm">
+          {items.map((r) => (
+            <li key={r.name} className="flex justify-between">
+              <span>{r.name}</span>
+              <span className="font-medium">{formatCurrency(r.amount)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
     </WidgetCard>
   );
 }

--- a/src/components/dashboard/WidgetCard.tsx
+++ b/src/components/dashboard/WidgetCard.tsx
@@ -1,10 +1,14 @@
-import type { PropsWithChildren } from "react";
+import type { HTMLAttributes, PropsWithChildren } from "react";
 import { Link } from "react-router-dom";
 import { ChevronRight } from "lucide-react";
 
 // Generic card used by dashboard widgets.
-export function WidgetCard({ className, children }: PropsWithChildren<{ className?: string }>) {
-  return <div className={`card-surface p-5 sm:p-6 ${className ?? ""}`}>{children}</div>;
+export function WidgetCard({ className, children, ...rest }: PropsWithChildren<HTMLAttributes<HTMLDivElement>>) {
+  return (
+    <div className={`card-surface p-5 sm:p-6 ${className ?? ""}`} {...rest}>
+      {children}
+    </div>
+  );
 }
 
 export function WidgetHeader({ title, subtitle }: { title: string; subtitle?: string }) {

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -1,3 +1,7 @@
+import { Link } from "react-router-dom";
+
+import { Button } from "./button";
+
 import { cn } from "@/lib/utils";
 
 interface EmptyStateProps {
@@ -5,9 +9,14 @@ interface EmptyStateProps {
   title?: string;
   message?: string;
   className?: string;
+  action?: {
+    label: string;
+    href?: string;
+    onClick?: () => void;
+  };
 }
 
-export function EmptyState({ icon, title, message, className }: EmptyStateProps) {
+export function EmptyState({ icon, title, message, className, action }: EmptyStateProps) {
   return (
     <div
       className={cn(
@@ -18,6 +27,17 @@ export function EmptyState({ icon, title, message, className }: EmptyStateProps)
       {icon ? <div className="mb-2">{icon}</div> : null}
       {title ? <h3 className="text-sm font-medium">{title}</h3> : null}
       {message ? <p className="text-sm">{message}</p> : null}
+      {action ? (
+        action.href ? (
+          <Button asChild className="mt-2">
+            <Link to={action.href}>{action.label}</Link>
+          </Button>
+        ) : (
+          <Button className="mt-2" onClick={action.onClick}>
+            {action.label}
+          </Button>
+        )
+      ) : null}
     </div>
   );
 }

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -29,6 +29,7 @@ import { Skeleton } from "@/components/ui/Skeleton";
 import { EmptyState } from "@/components/ui/EmptyState";
 import ForecastChart from "@/components/dashboard/ForecastChart";
 import AlertList from "@/components/dashboard/AlertList";
+import AlertsWidget from "@/components/dashboard/AlertsWidget";
 import InsightCard from "@/components/dashboard/InsightCard";
 import {
   WidgetCard,
@@ -312,7 +313,7 @@ export default function Dashboard() {
           <BalanceForecast current={kpis.saldoMes} forecast={kpis.saldoMes + 1000} onClick={() => setActiveWidget('balance')} />
         </motion.div>
         <motion.div variants={item}>
-          <AlertList alerts={alerts} onClick={() => setActiveWidget('alerts')} />
+          <AlertsWidget alerts={alerts} onClick={() => setActiveWidget('alerts')} />
         </motion.div>
       </motion.div>
 


### PR DESCRIPTION
## Summary
- extend EmptyState with optional action CTA
- show placeholders for empty recurrence, goals, alerts, and bills widgets
- allow WidgetCard to forward HTML attributes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e08c30aec8322a1b7e2b72f01990f