### PR TITLE
feat: add finance links to dashboard widgets

### DIFF
--- a/src/components/dashboard/BalanceForecast.tsx
+++ b/src/components/dashboard/BalanceForecast.tsx
@@ -1,4 +1,4 @@
-import WidgetCard from './WidgetCard';
+import { WidgetCard, WidgetHeader, WidgetFooterAction } from './WidgetCard';
 
 import { formatCurrency } from '@/lib/utils';
 
@@ -11,11 +11,13 @@ interface BalanceForecastProps {
 export default function BalanceForecast({ current, forecast, ...rest }: BalanceForecastProps) {
   const diff = forecast - current;
   return (
-    <WidgetCard title="Saldo em 30 dias" {...rest}>
+    <WidgetCard {...rest}>
+      <WidgetHeader title="Saldo em 30 dias" />
       <p className="text-2xl font-semibold">{formatCurrency(forecast)}</p>
       <p className="text-sm text-muted-foreground">
         {diff >= 0 ? '+' : '-'}{formatCurrency(Math.abs(diff))} em relação ao atual
       </p>
+      <WidgetFooterAction to="/financas/anual">Ver detalhes</WidgetFooterAction>
     </WidgetCard>
   );
 }

--- a/src/components/dashboard/RecurrenceList.tsx
+++ b/src/components/dashboard/RecurrenceList.tsx
@@ -1,4 +1,4 @@
-import WidgetCard from './WidgetCard';
+import { WidgetCard, WidgetHeader, WidgetFooterAction } from './WidgetCard';
 
 import { formatCurrency } from '@/lib/utils';
 
@@ -14,7 +14,8 @@ interface RecurrenceListProps {
 
 export default function RecurrenceList({ items, ...rest }: RecurrenceListProps) {
   return (
-    <WidgetCard title="Despesas fixas" {...rest}>
+    <WidgetCard {...rest}>
+      <WidgetHeader title="Despesas fixas" />
       <ul className="space-y-1 text-sm">
         {items.map((r) => (
           <li key={r.name} className="flex justify-between">
@@ -23,6 +24,7 @@ export default function RecurrenceList({ items, ...rest }: RecurrenceListProps) 
           </li>
         ))}
       </ul>
+      <WidgetFooterAction to="/financas/mensal">Ver detalhes</WidgetFooterAction>
     </WidgetCard>
   );
 }

--- a/src/components/dashboard/WidgetCard.tsx
+++ b/src/components/dashboard/WidgetCard.tsx
@@ -16,13 +16,13 @@ export function WidgetHeader({ title, subtitle }: { title: string; subtitle?: st
   );
 }
 
-export function WidgetFooterAction({ to, label }: { to: string; label: string }) {
+export function WidgetFooterAction({ to, children }: PropsWithChildren<{ to: string }>) {
   return (
     <Link
       to={to}
       className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-emerald-700 hover:underline"
     >
-      {label}
+      {children}
       <ChevronRight className="size-4" />
     </Link>
   );

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -443,9 +443,9 @@ export default function Dashboard() {
                 </ul>
               </>
             )}
-            </Card>
+              </WidgetCard>
+          </motion.div>
         </motion.div>
-      </motion.div>
 
       <motion.div className="grid items-stretch gap-6 xl:grid-cols-3" variants={container}>
         <motion.div variants={item}>
@@ -455,7 +455,7 @@ export default function Dashboard() {
               subtitle="Próximos 10 dias"
             />
             <AlertList items={contasAVencer} />
-            <WidgetFooterAction to="/financas/mensal" label="Ver Finanças" />
+            <WidgetFooterAction to="/financas/mensal">Ver detalhes</WidgetFooterAction>
           </WidgetCard>
         </motion.div>
 
@@ -466,10 +466,7 @@ export default function Dashboard() {
               subtitle="Progresso geral"
             />
             <MetasSummary />
-            <WidgetFooterAction
-              to="/metas"
-              label="Ir para Metas & Projetos"
-            />
+            <WidgetFooterAction to="/financas/anual">Ver detalhes</WidgetFooterAction>
           </WidgetCard>
         </motion.div>
 
@@ -520,6 +517,7 @@ export default function Dashboard() {
                 </tbody>
               </table>
             </div>
+            <WidgetFooterAction to="/financas/mensal">Ver detalhes</WidgetFooterAction>
           </WidgetCard>
         </motion.div>
       </motion.div>


### PR DESCRIPTION
## Summary
- add "Ver detalhes" links to recurrence and balance widgets
- route dashboard widgets to mensal or anual finance views
- allow custom footer link content for WidgetFooterAction

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-storybook')*
- `npm run typecheck`
- `npm run build` *(fails: Cannot find module 'react', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689e08bdf6808322903f2fd08fc842a3