### PR TITLE
feat: add empty state cta and summary placeholders

### DIFF
--- a/src/components/ui/EmptyState.stories.tsx
+++ b/src/components/ui/EmptyState.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { AlertCircle } from 'lucide-react';
 
 import { EmptyState } from './EmptyState';
+import { Button } from './button';
 
 const meta: Meta<typeof EmptyState> = {
   title: 'Components/EmptyState',
@@ -17,5 +18,14 @@ export const Default: Story = {
     icon: <AlertCircle className="h-6 w-6" />,
     title: 'Nothing here',
     message: 'Add something to get started.',
+  },
+};
+
+export const WithAction: Story = {
+  args: {
+    icon: <AlertCircle className="h-6 w-6" />,
+    title: 'Nothing here',
+    message: 'Add something to get started.',
+    action: <Button size="sm">Create item</Button>,
   },
 };

--- a/src/components/ui/EmptyState.tsx
+++ b/src/components/ui/EmptyState.tsx
@@ -4,10 +4,11 @@ interface EmptyStateProps {
   icon?: React.ReactNode;
   title?: string;
   message?: string;
+  action?: React.ReactNode;
   className?: string;
 }
 
-export function EmptyState({ icon, title, message, className }: EmptyStateProps) {
+export function EmptyState({ icon, title, message, action, className }: EmptyStateProps) {
   return (
     <div
       className={cn(
@@ -18,6 +19,7 @@ export function EmptyState({ icon, title, message, className }: EmptyStateProps)
       {icon ? <div className="mb-2">{icon}</div> : null}
       {title ? <h3 className="text-sm font-medium">{title}</h3> : null}
       {message ? <p className="text-sm">{message}</p> : null}
+      {action ? <div className="mt-2">{action}</div> : null}
     </div>
   );
 }

--- a/src/pages/FinancasResumo.tsx
+++ b/src/pages/FinancasResumo.tsx
@@ -10,6 +10,7 @@ import DailyBars from "@/components/charts/DailyBars";
 import CategoryDonut from "@/components/charts/CategoryDonut";
 import AlertList from "@/components/dashboard/AlertList";
 import { Button } from "@/components/ui/button";
+import { EmptyState } from "@/components/ui/EmptyState";
 import { ModalTransacao, type BaseData } from "@/components/ModalTransacao";
 import { usePeriod } from "@/state/periodFilter";
 import { useTransactions } from "@/hooks/useTransactions";
@@ -139,70 +140,122 @@ export default function FinancasResumo() {
       <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
         <WidgetCard className="glass-card">
           <WidgetHeader title="Fluxo de caixa mensal" />
-          <DailyBars transacoes={uiTransacoes} mes={`${year}-${String(month).padStart(2, "0")}`} />
+          {uiTransacoes.length > 0 ? (
+            <DailyBars transacoes={uiTransacoes} mes={`${year}-${String(month).padStart(2, "0")}`} />
+          ) : (
+            <EmptyState
+              title="Sem transações"
+              message="Adicione uma transação para ver o fluxo de caixa."
+              action={<Button size="sm" onClick={() => setModalOpen(true)}>Nova transação</Button>}
+            />
+          )}
           <WidgetFooterAction to="/financas/mensal" label="Ver detalhes" />
         </WidgetCard>
 
         <WidgetCard className="glass-card">
           <WidgetHeader title="Entradas vs saídas (12 meses)" />
-          <div className="h-56">
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart data={last12}>
-                <XAxis dataKey="mes" />
-                <YAxis />
-                <Tooltip formatter={(v: number) => formatCurrency(v)} />
-                <Legend />
-                <Bar dataKey="entradas" fill="#10b981" />
-                <Bar dataKey="saidas" fill="#ef4444" />
-              </BarChart>
-            </ResponsiveContainer>
-          </div>
+          {uiTransacoes.length > 0 ? (
+            <div className="h-56">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={last12}>
+                  <XAxis dataKey="mes" />
+                  <YAxis />
+                  <Tooltip formatter={(v: number) => formatCurrency(v)} />
+                  <Legend />
+                  <Bar dataKey="entradas" fill="#10b981" />
+                  <Bar dataKey="saidas" fill="#ef4444" />
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+          ) : (
+            <EmptyState
+              title="Sem dados"
+              message="Adicione transações para visualizar."
+              action={<Button size="sm" onClick={() => setModalOpen(true)}>Nova transação</Button>}
+            />
+          )}
           <WidgetFooterAction to="/financas/anual" label="Ver detalhes" />
         </WidgetCard>
 
         <WidgetCard className="glass-card">
           <WidgetHeader title="Despesas por categoria" />
-          <CategoryDonut categoriesData={budgetUsage.map(b => ({ category: b.category, value: b.spent }))} />
+          {budgetUsage.length > 0 ? (
+            <CategoryDonut categoriesData={budgetUsage.map(b => ({ category: b.category, value: b.spent }))} />
+          ) : (
+            <EmptyState
+              title="Sem dados"
+              message="Adicione transações para ver categorias."
+              action={<Button size="sm" onClick={() => setModalOpen(true)}>Nova transação</Button>}
+            />
+          )}
           <WidgetFooterAction to="/financas/mensal" label="Ver detalhes" />
         </WidgetCard>
 
         <WidgetCard className="glass-card">
           <WidgetHeader title="Contas a vencer" />
-          <AlertList items={upcomingBills} />
+          {upcomingBills.length > 0 ? (
+            <AlertList items={upcomingBills} />
+          ) : (
+            <EmptyState
+              title="Nenhuma conta a vencer"
+              action={<Button size="sm" onClick={() => setModalOpen(true)}>Nova transação</Button>}
+            />
+          )}
           <WidgetFooterAction to="/financas/mensal" label="Ver detalhes" />
         </WidgetCard>
 
         <WidgetCard className="glass-card">
           <WidgetHeader title="Lançamentos recentes" />
-          <ul className="divide-y divide-zinc-100/60 dark:divide-zinc-800/60">
-            {uiTransacoes.slice(0, 5).map(t => (
-              <li key={t.id} className="flex justify-between py-2 text-sm">
-                <span className="truncate pr-2">{t.description}</span>
-                <span className={t.type === "income" ? "text-emerald-600" : "text-rose-600"}>
-                  {formatCurrency(t.value * (t.type === "income" ? 1 : -1))}
-                </span>
-              </li>
-            ))}
-          </ul>
+          {uiTransacoes.length > 0 ? (
+            <ul className="divide-y divide-zinc-100/60 dark:divide-zinc-800/60">
+              {uiTransacoes.slice(0, 5).map(t => (
+                <li key={t.id} className="flex justify-between py-2 text-sm">
+                  <span className="truncate pr-2">{t.description}</span>
+                  <span className={t.type === "income" ? "text-emerald-600" : "text-rose-600"}>
+                    {formatCurrency(t.value * (t.type === "income" ? 1 : -1))}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <EmptyState
+              title="Nenhuma transação"
+              action={<Button size="sm" onClick={() => setModalOpen(true)}>Nova transação</Button>}
+            />
+          )}
           <WidgetFooterAction to="/financas/mensal" label="Ver detalhes" />
         </WidgetCard>
 
         <WidgetCard className="glass-card">
           <WidgetHeader title="Orçamento do mês" />
-          <ul className="space-y-2">
-            {budgetUsage.slice(0, 5).map(b => (
-              <li key={b.category} className="flex justify-between text-sm">
-                <span>{b.category}</span>
-                <span>{formatCurrency(b.spent)}</span>
-              </li>
-            ))}
-          </ul>
+          {budgetUsage.length > 0 ? (
+            <ul className="space-y-2">
+              {budgetUsage.slice(0, 5).map(b => (
+                <li key={b.category} className="flex justify-between text-sm">
+                  <span>{b.category}</span>
+                  <span>{formatCurrency(b.spent)}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <EmptyState
+              title="Sem orçamento"
+              action={<Button size="sm" onClick={() => setModalOpen(true)}>Nova transação</Button>}
+            />
+          )}
           <WidgetFooterAction to="/financas/mensal" label="Ver detalhes" />
         </WidgetCard>
 
         <WidgetCard className="glass-card">
           <WidgetHeader title="Alertas" />
-          <AlertList items={upcomingBills} />
+          {upcomingBills.length > 0 ? (
+            <AlertList items={upcomingBills} />
+          ) : (
+            <EmptyState
+              title="Nenhum alerta"
+              action={<Button size="sm" onClick={() => setModalOpen(true)}>Nova transação</Button>}
+            />
+          )}
           <WidgetFooterAction to="/financas/mensal" label="Ver detalhes" />
         </WidgetCard>
       </div>


### PR DESCRIPTION
## Summary
- extend `EmptyState` component with optional CTA support
- show empty placeholders across `FinancasResumo` widgets when data is missing
- document `EmptyState` action via Storybook story

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm test` *(fails: Missing script: "test")*
- `npx vitest run` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_e_689e1450265c83228a48ac319de3a28d