### PR TITLE
feat: add insights bar

### DIFF
--- a/src/components/financas/InsightBar.tsx
+++ b/src/components/financas/InsightBar.tsx
@@ -1,0 +1,51 @@
+import { useEffect, useRef, useState } from 'react';
+
+import type { Insight } from '@/hooks/useInsights';
+
+export type InsightBarProps = {
+  insights: Insight[];
+};
+
+// Simple horizontal carousel for insights.
+// Auto-scrolls every few seconds, pauses on hover and allows manual
+// scroll on touch devices.
+export default function InsightBar({ insights }: InsightBarProps) {
+  const ref = useRef<HTMLDivElement>(null);
+  const [paused, setPaused] = useState(false);
+
+  useEffect(() => {
+    if (paused) return;
+    const el = ref.current;
+    if (!el || insights.length <= 1) return;
+    const timer = setInterval(() => {
+      const width = el.clientWidth;
+      if (Math.ceil(el.scrollLeft + width) >= el.scrollWidth) {
+        el.scrollTo({ left: 0, behavior: 'smooth' });
+      } else {
+        el.scrollBy({ left: width, behavior: 'smooth' });
+      }
+    }, 5000);
+    return () => clearInterval(timer);
+  }, [paused, insights.length]);
+
+  if (!insights.length) return null;
+
+  return (
+    <div
+      ref={ref}
+      onMouseEnter={() => setPaused(true)}
+      onMouseLeave={() => setPaused(false)}
+      className="flex overflow-x-auto snap-x snap-mandatory scroll-smooth"
+    >
+      {insights.map((ins) => (
+        <div
+          key={ins.id}
+          className="snap-center w-full shrink-0 p-4 text-sm card-surface"
+        >
+          {ins.message}
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/components/financas/index.ts
+++ b/src/components/financas/index.ts
@@ -18,3 +18,6 @@ export type { OrcamentoItem, OrcamentoProgressProps } from './OrcamentoProgress'
 
 export { default as AlertasList } from './AlertasList';
 export type { Alerta, AlertasListProps } from './AlertasList';
+
+export { default as InsightBar } from './InsightBar';
+export type { InsightBarProps } from './InsightBar';

--- a/src/hooks/useInsights.ts
+++ b/src/hooks/useInsights.ts
@@ -1,0 +1,178 @@
+import { useMemo } from 'react';
+
+import type { Transaction } from '@/hooks/useTransactions';
+import type { Category } from '@/hooks/useCategories';
+import type { Bill } from '@/hooks/useBills';
+import type { GoalRow } from '@/hooks/useGoals';
+
+export type Mile = {
+  program: string;
+  amount: number;
+  expires_at: string; // ISO date
+};
+
+export type Insight = {
+  id: string;
+  message: string;
+};
+
+export type InsightInput = {
+  transactions: Transaction[];
+  categories: Category[];
+  bills: Bill[];
+  goals: GoalRow[];
+  miles: Mile[];
+};
+
+/**
+ * Hook that derives small financial insights from the current data set.
+ *
+ * The algorithm is intentionally heuristic/approximate – it only
+ * computes insights when enough information is available and silently
+ * skips otherwise.
+ */
+export function useInsights(
+  period: { year: number; month: number },
+  { transactions, categories, bills, goals, miles }: InsightInput
+) {
+  return useMemo<Insight[]>(() => {
+    const out: Insight[] = [];
+    const { year, month } = period;
+
+    const pad = (m: number) => String(m).padStart(2, '0');
+    const ymCur = `${year}-${pad(month)}`;
+    const prev = new Date(year, month - 2, 1);
+    const ymPrev = `${prev.getFullYear()}-${pad(prev.getMonth() + 1)}`;
+
+    // ----- Variation in food category ---------------------------------
+    const foodCat = categories.find((c) =>
+      c.name.toLowerCase().includes('aliment')
+    );
+    if (foodCat) {
+      const sumFor = (ym: string) =>
+        transactions
+          .filter(
+            (t) =>
+              t.amount < 0 &&
+              t.category_id === foodCat.id &&
+              (t.date || '').startsWith(ym)
+          )
+          .reduce((s, t) => s + Math.abs(t.amount), 0);
+      const cur = sumFor(ymCur);
+      const prevV = sumFor(ymPrev);
+      if (prevV > 0) {
+        const pct = ((cur - prevV) / prevV) * 100;
+        out.push({
+          id: 'food-var',
+          message: `Gastos em alimentação ${
+            pct >= 0 ? 'aumentaram' : 'diminuíram'
+          } ${Math.abs(pct).toFixed(0)}% em relação ao mês anterior.`,
+        });
+      }
+    }
+
+    // ----- Category with greatest growth ------------------------------
+    const curByCat: Record<string, number> = {};
+    const prevByCat: Record<string, number> = {};
+    transactions.forEach((t) => {
+      if (t.amount >= 0) return;
+      const ym = (t.date || '').slice(0, 7);
+      const cat = t.category_id || 'uncat';
+      const val = Math.abs(t.amount);
+      if (ym === ymCur) curByCat[cat] = (curByCat[cat] || 0) + val;
+      else if (ym === ymPrev) prevByCat[cat] = (prevByCat[cat] || 0) + val;
+    });
+    let growthCat: string | null = null;
+    let growthPct = 0;
+    Object.keys(curByCat).forEach((cat) => {
+      const cur = curByCat[cat];
+      const prevV = prevByCat[cat] || 0;
+      if (prevV === 0) return;
+      const g = (cur - prevV) / prevV;
+      if (g > growthPct) {
+        growthPct = g;
+        growthCat = cat;
+      }
+    });
+    if (growthCat) {
+      const name =
+        categories.find((c) => c.id === growthCat)?.name || 'Alguma categoria';
+      out.push({
+        id: 'cat-growth',
+        message: `${name} teve o maior crescimento de gastos (${(
+          growthPct * 100
+        ).toFixed(0)}%).`,
+      });
+    }
+
+    // ----- Budget nearing 85% -----------------------------------------
+    const spentByCat: Record<string, number> = {};
+    transactions
+      .filter((t) => t.amount < 0 && (t.date || '').startsWith(ymCur))
+      .forEach((t) => {
+        const key = t.category_id || 'uncat';
+        spentByCat[key] = (spentByCat[key] || 0) + Math.abs(t.amount);
+      });
+    type BudgetedCategory = Category & { budget?: number };
+    const budgetHit = (categories as BudgetedCategory[]).find((c) => {
+      if (!c.budget) return false;
+      const spent = spentByCat[c.id] || 0;
+      return spent / c.budget >= 0.85;
+    });
+    if (budgetHit) {
+      const spent = spentByCat[budgetHit.id] || 0;
+      const pct = Math.round((spent / (budgetHit.budget || 1)) * 100);
+      out.push({
+        id: `budget-${budgetHit.id}`,
+        message: `${budgetHit.name} já atingiu ${pct}% do orçamento do mês.`,
+      });
+    }
+
+    // ----- Miles expiring soon ----------------------------------------
+    const soon = miles.filter((m) => {
+      const d = new Date(m.expires_at);
+      const now = new Date();
+      const diff = d.getTime() - now.getTime();
+      return diff > 0 && diff < 1000 * 60 * 60 * 24 * 30; // 30 dias
+    });
+    soon.forEach((m) => {
+      out.push({
+        id: `mile-${m.program}-${m.expires_at}`,
+        message: `${m.amount} milhas em ${m.program} expiram em ${new Date(
+          m.expires_at
+        ).toLocaleDateString('pt-BR')}.`,
+      });
+    });
+
+    // ----- Bills due soon ---------------------------------------------
+    bills
+      .filter((b) => {
+        if (b.paid) return false;
+        const diff = new Date(b.due_date).getTime() - Date.now();
+        return diff > 0 && diff < 1000 * 60 * 60 * 24 * 7; // 7 dias
+      })
+      .forEach((b) => {
+        out.push({
+          id: `bill-${b.id}`,
+          message: `Conta "${b.description}" vence em ${new Date(
+            b.due_date
+          ).toLocaleDateString('pt-BR')}.`,
+        });
+      });
+
+    // ----- Goals close to deadline ------------------------------------
+    goals
+      .filter((g) => g.days_remaining <= 30 && g.progress_pct < 100)
+      .forEach((g) => {
+        out.push({
+          id: `goal-${g.id}`,
+          message: `Meta "${g.title}" expira em ${g.days_remaining} dias.`,
+        });
+      });
+
+    return out;
+  }, [period, transactions, categories, bills, goals, miles]);
+}
+
+export type UseInsightsReturn = ReturnType<typeof useInsights>;
+

--- a/src/pages/FinancasResumo.tsx
+++ b/src/pages/FinancasResumo.tsx
@@ -16,6 +16,8 @@ import { usePeriod } from "@/state/periodFilter";
 import { useTransactions } from "@/hooks/useTransactions";
 import { useBills } from "@/hooks/useBills";
 import { useCategories } from "@/hooks/useCategories";
+import InsightBar from "@/components/financas/InsightBar";
+import { useInsights } from "@/hooks/useInsights";
 import { exportTransactionsPDF } from "@/utils/pdf";
 import { formatCurrency } from "@/lib/utils";
 import { getMonthlyAggregates, getLast12MonthsAggregates, getUpcomingBills, getBudgetUsage } from "@/lib/finance";
@@ -50,6 +52,10 @@ export default function FinancasResumo() {
   const upcomingBills = useMemo(() => getUpcomingBills(contas).map(b => ({ nome: b.description, vencimento: b.due_date, valor: b.amount })), [contas]);
   const budgetUsage = useMemo(() => getBudgetUsage(categorias, transacoes), [categorias, transacoes]);
   const last12 = useMemo(() => getLast12MonthsAggregates(transacoes).map(m => ({ mes: m.key.slice(5), entradas: m.income, saidas: m.expense })), [transacoes]);
+  const insights = useInsights(
+    { year, month },
+    { transactions: transacoes, categories: categorias, bills: contas, goals: [], miles: [] }
+  );
 
   const handlePDF = () => {
     exportTransactionsPDF(
@@ -136,6 +142,8 @@ export default function FinancasResumo() {
       </div>
 
       <KPIStrip items={kpiItems} />
+
+      {insights.length > 0 && <InsightBar insights={insights} />}
 
       <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
         <WidgetCard className="glass-card">

--- a/src/pages/HomeOverview.tsx
+++ b/src/pages/HomeOverview.tsx
@@ -39,6 +39,8 @@ import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { formatCurrency } from "@/lib/utils";
 import { usePeriod } from "@/state/periodFilter";
+import InsightBar from "@/components/financas/InsightBar";
+import { useInsights } from "@/hooks/useInsights";
 
 
 // Garantir decorativos não interativos
@@ -173,6 +175,25 @@ export default function HomeOverview() {
   ];
 
   const { mode, month, year } = usePeriod();
+  const insights = useInsights(
+    { year, month },
+    {
+      transactions: [],
+      categories: [],
+      bills: contasAVencer.map((c, i) => ({
+        id: String(i),
+        description: c.nome,
+        amount: c.valor,
+        due_date: c.vencimento,
+        paid: false,
+        account_id: null,
+        card_id: null,
+        category_id: null,
+      })),
+      goals: [],
+      miles: [],
+    }
+  );
 
   const fluxoTitle = `Fluxo de caixa — ${mode === "monthly" ? `${monthShortPtBR(month)} ${year}` : `Ano ${year}`}`;
 
@@ -296,6 +317,11 @@ export default function HomeOverview() {
         </motion.div>
 
       </motion.div>
+      {insights.length > 0 && (
+        <motion.div variants={item}>
+          <InsightBar insights={insights} />
+        </motion.div>
+      )}
 
       {/* WIDGETS ----------------------------------------------- */}
       <motion.div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3" variants={container}>


### PR DESCRIPTION
## Summary
- add heuristic `useInsights` hook to derive messages from transactions, bills, goals and miles
- build `InsightBar` carousel for auto-rotating insights
- show insights beneath KPIs on HomeOverview and Finanças Resumo

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e17c84fec8322956a0798457da5f7