### PR TITLE
feat: detect recurring transactions

### DIFF
--- a/src/components/dashboard/RecurrenceList.tsx
+++ b/src/components/dashboard/RecurrenceList.tsx
@@ -15,7 +15,7 @@ interface RecurrenceListProps {
 export default function RecurrenceList({ items, ...rest }: RecurrenceListProps) {
   return (
     <WidgetCard {...rest}>
-      <WidgetHeader title="Despesas fixas" />
+      <WidgetHeader title="Recorrências detectadas" />
       <ul className="space-y-1 text-sm">
         {items.map((r) => (
           <li key={r.name} className="flex justify-between">
@@ -24,7 +24,7 @@ export default function RecurrenceList({ items, ...rest }: RecurrenceListProps) 
           </li>
         ))}
       </ul>
-      <WidgetFooterAction to="/financas/mensal">Ver detalhes</WidgetFooterAction>
+      <WidgetFooterAction to="/financas/recorrencias">Ver/editar</WidgetFooterAction>
     </WidgetCard>
   );
 }

--- a/src/hooks/useRecurrences.ts
+++ b/src/hooks/useRecurrences.ts
@@ -1,0 +1,97 @@
+import { useEffect, useState } from "react";
+
+import { supabase } from "@/lib/supabaseClient";
+
+export type Recurrence = {
+  description: string;
+  amount: number;
+  nextDate: string;
+};
+
+function normalizeDescription(desc: string) {
+  return (desc || "")
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/\s*\(\s*\d+\s*\/\s*\d+\s*\)\s*$/, "")
+    .replace(/\d+/g, "")
+    .replace(/[^\w\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function diffDays(a: string, b: string) {
+  const da = Date.parse(a + "T00:00:00Z");
+  const db = Date.parse(b + "T00:00:00Z");
+  return Math.round((da - db) / 86400000);
+}
+
+function addDays(iso: string, days: number) {
+  const [Y, M, D] = iso.split("-").map(Number);
+  const d = new Date(Date.UTC(Y, M - 1, D + days));
+  return d.toISOString().slice(0, 10);
+}
+
+function detectRecurrences(rows: Array<{ date: string; amount: number; description: string }>) {
+  const groups: Record<string, { name: string; items: { date: string; amount: number }[] }> = {};
+  rows.forEach((r) => {
+    const norm = normalizeDescription(r.description);
+    if (!norm) return;
+    if (!groups[norm]) groups[norm] = { name: r.description, items: [] };
+    groups[norm].name = r.description; // keep latest description
+    groups[norm].items.push({ date: r.date, amount: Number(r.amount) });
+  });
+
+  const out: Recurrence[] = [];
+  Object.values(groups).forEach((g) => {
+    if (g.items.length < 3) return;
+    g.items.sort((a, b) => a.date.localeCompare(b.date));
+    const diffs: number[] = [];
+    for (let i = 1; i < g.items.length; i++) {
+      diffs.push(diffDays(g.items[i].date, g.items[i - 1].date));
+    }
+    if (diffs.length < 2) return;
+    const avg = diffs.reduce((a, b) => a + b, 0) / diffs.length;
+    const period = Math.round(avg);
+    if (!diffs.every((d) => Math.abs(d - period) <= 3)) return;
+    const last = g.items[g.items.length - 1];
+    const nextDate = addDays(last.date, period);
+    const amountAvg = g.items.reduce((a, b) => a + b.amount, 0) / g.items.length;
+    out.push({ description: g.name, amount: amountAvg, nextDate });
+  });
+  return out;
+}
+
+export function useRecurrences() {
+  const [data, setData] = useState<Recurrence[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const { data, error } = await supabase
+          .from("transactions")
+          .select("date, amount, description")
+          .order("date", { ascending: true });
+        if (error) throw error;
+        const recs = detectRecurrences((data || []) as any[]);
+        setData(recs);
+      } catch (e: unknown) {
+        console.error("[useRecurrences] list error:", e);
+        setError(e instanceof Error ? e.message : "Erro ao carregar recorrências");
+        setData([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+    void load();
+  }, []);
+
+  return { data, loading, error };
+}
+
+export type RecurrenceResult = ReturnType<typeof useRecurrences>;
+

--- a/src/pages/FinancasResumo.tsx
+++ b/src/pages/FinancasResumo.tsx
@@ -9,6 +9,7 @@ import { WidgetCard, WidgetHeader, WidgetFooterAction } from "@/components/dashb
 import DailyBars from "@/components/charts/DailyBars";
 import CategoryDonut from "@/components/charts/CategoryDonut";
 import AlertList from "@/components/dashboard/AlertList";
+import RecurrenceList from "@/components/dashboard/RecurrenceList";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { ModalTransacao, type BaseData } from "@/components/ModalTransacao";
@@ -16,6 +17,7 @@ import { usePeriod } from "@/state/periodFilter";
 import { useTransactions } from "@/hooks/useTransactions";
 import { useBills } from "@/hooks/useBills";
 import { useCategories } from "@/hooks/useCategories";
+import { useRecurrences } from "@/hooks/useRecurrences";
 import { exportTransactionsPDF } from "@/utils/pdf";
 import { formatCurrency } from "@/lib/utils";
 import { getMonthlyAggregates, getLast12MonthsAggregates, getUpcomingBills, getBudgetUsage } from "@/lib/finance";
@@ -26,6 +28,7 @@ export default function FinancasResumo() {
   const { data: transacoes, addSmart, list } = useTransactions(year, month);
   const { data: contas } = useBills(year, month);
   const { flat: categorias } = useCategories();
+  const { data: recurrences } = useRecurrences();
   const [modalOpen, setModalOpen] = useState(false);
 
   const uiTransacoes: UITransaction[] = useMemo(() => {
@@ -203,6 +206,11 @@ export default function FinancasResumo() {
           )}
           <WidgetFooterAction to="/financas/mensal" label="Ver detalhes" />
         </WidgetCard>
+
+        <RecurrenceList
+          className="glass-card"
+          items={recurrences.map((r) => ({ name: r.description, amount: r.amount }))}
+        />
 
         <WidgetCard className="glass-card">
           <WidgetHeader title="Lançamentos recentes" />

--- a/src/pages/HomeOverview.tsx
+++ b/src/pages/HomeOverview.tsx
@@ -35,6 +35,7 @@ import {
   WidgetFooterAction,
   WidgetHeader,
 } from "@/components/dashboard/WidgetCard";
+import { useRecurrences } from "@/hooks/useRecurrences";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { Skeleton } from "@/components/ui/Skeleton";
 import { formatCurrency } from "@/lib/utils";
@@ -123,11 +124,7 @@ export default function HomeOverview() {
 
   const insightMessage = "Você economizou 15% a mais este mês.";
   const forecastData = base.slice(-6).map((d) => ({ month: d.m, in: d.in, out: d.out }));
-  const recurrences = [
-    { name: "Aluguel", amount: 1500 },
-    { name: "Academia", amount: 90 },
-    { name: "Internet", amount: 120 },
-  ];
+  const { data: recurrences } = useRecurrences();
   const alerts = [
     { message: "Conta de luz vence em 3 dias" },
     { message: "Orçamento de lazer excedido" },
@@ -306,7 +303,10 @@ export default function HomeOverview() {
           <ForecastChart data={forecastData} onClick={() => setActiveWidget('forecast')} />
         </motion.div>
         <motion.div variants={item}>
-          <RecurrenceList items={recurrences} onClick={() => setActiveWidget('recurrence')} />
+          <RecurrenceList
+            items={recurrences.map((r) => ({ name: r.description, amount: r.amount }))}
+            onClick={() => setActiveWidget('recurrence')}
+          />
         </motion.div>
         <motion.div variants={item}>
           <BalanceForecast current={kpis.saldoMes} forecast={kpis.saldoMes + 1000} onClick={() => setActiveWidget('balance')} />


### PR DESCRIPTION
## Summary
- add `useRecurrences` hook to group transactions by normalized description and period
- surface "Recorrências detectadas" widget on overview and finance summary pages
- update recurrence list widget with new title and CTA for editing

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e17d12c648322ac0de455a5b47444