### PR TITLE
feat: add alerts drawer with bell icon

### DIFF
--- a/src/components/AppTopbar.tsx
+++ b/src/components/AppTopbar.tsx
@@ -3,6 +3,7 @@ import { NavLink, useLocation, useNavigate } from 'react-router-dom';
 import { ChevronDown, Settings } from 'lucide-react';
 
 import { ThemeToggle } from './ui/ThemeToggle';
+import AlertsDrawer from './financas/AlertsDrawer';
 import { Logo } from './Logo';
 import {
   DropdownMenu,
@@ -101,6 +102,7 @@ export default function AppTopbar() {
           })}
         </nav>
         <div className="ml-auto flex items-center gap-2">
+          <AlertsDrawer />
           <ThemeToggle />
           <NavLink
             to="/configuracoes"

--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -3,6 +3,7 @@ import { NavLink, useLocation, useNavigate } from "react-router-dom";
 import { ChevronDown, Settings } from "lucide-react";
 
 import { ThemeToggle } from "./ui/ThemeToggle";
+import AlertsDrawer from "./financas/AlertsDrawer";
 import { Logo } from "./Logo";
 import {
   DropdownMenu,
@@ -96,6 +97,7 @@ export default function TopNav() {
           })}
         </nav>
         <div className="ml-auto flex items-center gap-2">
+          <AlertsDrawer />
           <ThemeToggle />
           <NavLink
             to="/configuracoes"

--- a/src/components/financas/AlertsDrawer.tsx
+++ b/src/components/financas/AlertsDrawer.tsx
@@ -1,0 +1,85 @@
+import * as React from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { Bell } from 'lucide-react';
+import { Link } from 'react-router-dom';
+
+import { Switch } from '@/components/ui/switch';
+import { Input } from '@/components/ui/input';
+import { useAlerts, AlertType } from '@/hooks/useAlerts';
+
+const labels: Record<AlertType, { name: string; to: string }> = {
+  bills: { name: 'Contas a vencer', to: '/financas/mensal' },
+  budget: { name: 'Orçamento', to: '/financas/resumo' },
+  goals: { name: 'Metas', to: '/metas' },
+  miles: { name: 'Milhas', to: '/milhas' },
+};
+
+export default function AlertsDrawer() {
+  const { config, updateConfig, activeAlerts, count } = useAlerts();
+
+  return (
+    <Dialog.Root>
+      <Dialog.Trigger asChild>
+        <button
+          type="button"
+          className="relative inline-flex h-9 w-9 items-center justify-center rounded-xl text-white hover:bg-white/20"
+          aria-label="Alertas"
+        >
+          <Bell className="h-4 w-4" />
+          {count > 0 && (
+            <span className="absolute -top-1 -right-1 inline-flex h-4 min-w-[1rem] items-center justify-center rounded-full bg-rose-500 px-1 text-[10px] font-medium text-white">
+              {count}
+            </span>
+          )}
+        </button>
+      </Dialog.Trigger>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+        <Dialog.Content className="fixed right-0 top-0 z-50 flex h-full w-80 flex-col bg-background p-4 shadow-xl focus:outline-none">
+          <Dialog.Title className="text-lg font-semibold">Alertas</Dialog.Title>
+          <div className="mt-4 flex-1 overflow-auto">
+            {activeAlerts.length === 0 ? (
+              <p className="text-sm text-muted-foreground">Sem alertas ativos.</p>
+            ) : (
+              <ul className="space-y-2 text-sm">
+                {activeAlerts.map((a) => (
+                  <li key={a.type} className="flex items-center justify-between rounded-md border p-2">
+                    <span>{labels[a.type].name}</span>
+                    <Link
+                      to={a.cta}
+                      className="text-emerald-700 hover:underline"
+                    >
+                      Ver
+                    </Link>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div className="mt-6 space-y-4">
+              {(['bills', 'budget', 'goals', 'miles'] as AlertType[]).map((key) => (
+                <div key={key} className="flex items-center justify-between">
+                  <div className="space-y-1">
+                    <span className="text-sm font-medium">{labels[key].name}</span>
+                    <Input
+                      type="number"
+                      value={config[key].limit}
+                      onChange={(e) =>
+                        updateConfig(key, { limit: Number(e.target.value) })
+                      }
+                      className="h-8 w-20 text-sm"
+                    />
+                  </div>
+                  <Switch
+                    checked={config[key].enabled}
+                    onCheckedChange={(v) => updateConfig(key, { enabled: v })}
+                  />
+                </div>
+              ))}
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+

--- a/src/components/financas/index.ts
+++ b/src/components/financas/index.ts
@@ -18,3 +18,5 @@ export type { OrcamentoItem, OrcamentoProgressProps } from './OrcamentoProgress'
 
 export { default as AlertasList } from './AlertasList';
 export type { Alerta, AlertasListProps } from './AlertasList';
+
+export { default as AlertsDrawer } from './AlertsDrawer';

--- a/src/components/layout/AppTopbar.tsx
+++ b/src/components/layout/AppTopbar.tsx
@@ -5,6 +5,7 @@ import { motion } from "framer-motion";
 
 import { Logo } from "../Logo";
 import { ThemeToggle } from "../ui/ThemeToggle";
+import AlertsDrawer from "../financas/AlertsDrawer";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -55,6 +56,7 @@ export default function AppTopbar() {
           </NavLink>
         </nav>
         <div className="ml-auto flex items-center gap-2">
+          <AlertsDrawer />
           <ThemeToggle className="focus:outline-none focus:ring-2 focus:ring-emerald-400/70 dark:focus:ring-emerald-300/50" />
           <NavLink
             to="/configuracoes"

--- a/src/hooks/useAlerts.ts
+++ b/src/hooks/useAlerts.ts
@@ -1,0 +1,97 @@
+import { useEffect, useMemo, useState } from 'react';
+
+export type AlertType = 'bills' | 'budget' | 'goals' | 'miles';
+
+export type AlertConfig = {
+  enabled: boolean;
+  limit: number;
+};
+
+export type AlertsConfig = Record<AlertType, AlertConfig>;
+
+export type ActiveAlert = {
+  type: AlertType;
+  message: string;
+  cta: string;
+};
+
+const STORAGE_KEY = 'fy_alerts_config';
+
+const defaultConfig: AlertsConfig = {
+  bills: { enabled: true, limit: 7 },
+  budget: { enabled: true, limit: 80 },
+  goals: { enabled: true, limit: 80 },
+  miles: { enabled: true, limit: 30 },
+};
+
+function loadConfig(): AlertsConfig {
+  if (typeof window === 'undefined') return defaultConfig;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultConfig;
+    const parsed = JSON.parse(raw) as AlertsConfig;
+    return {
+      bills: { ...defaultConfig.bills, ...parsed.bills },
+      budget: { ...defaultConfig.budget, ...parsed.budget },
+      goals: { ...defaultConfig.goals, ...parsed.goals },
+      miles: { ...defaultConfig.miles, ...parsed.miles },
+    };
+  } catch {
+    return defaultConfig;
+  }
+}
+
+export function useAlerts() {
+  const [config, setConfig] = useState<AlertsConfig>(loadConfig);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(config));
+    }
+  }, [config]);
+
+  const activeAlerts = useMemo<ActiveAlert[]>(() => {
+    const list: ActiveAlert[] = [];
+    if (config.bills.enabled) {
+      list.push({
+        type: 'bills',
+        message: 'Contas a vencer',
+        cta: '/financas/mensal',
+      });
+    }
+    if (config.budget.enabled) {
+      list.push({
+        type: 'budget',
+        message: 'Orçamento perto do limite',
+        cta: '/financas/resumo',
+      });
+    }
+    if (config.goals.enabled) {
+      list.push({
+        type: 'goals',
+        message: 'Metas em risco',
+        cta: '/metas',
+      });
+    }
+    if (config.miles.enabled) {
+      list.push({
+        type: 'miles',
+        message: 'Milhas a expirar',
+        cta: '/milhas',
+      });
+    }
+    return list;
+  }, [config]);
+
+  const updateConfig = (type: AlertType, patch: Partial<AlertConfig>) => {
+    setConfig((prev) => ({
+      ...prev,
+      [type]: { ...prev[type], ...patch },
+    }));
+  };
+
+  return { config, updateConfig, activeAlerts, count: activeAlerts.length };
+}
+
+export default useAlerts;
+


### PR DESCRIPTION
## Summary
- add `useAlerts` hook persisting config to localStorage and exposing active alerts
- create `AlertsDrawer` with alert list and configurable toggles
- show bell icon in top bars to open drawer

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e17d4a7948322bd11a91b07d9ef56