### PR TITLE
feat: add glass and hero gradient styles

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import App from '@/App'
 import AppErrorBoundary from '@/components/AppErrorBoundary'
 import { Toaster } from '@/components/ui/Toasts'
 import '@/index.css'
+import '@/styles/glass.css'
 
 if ('serviceWorker' in navigator && import.meta.env.PROD) {
   navigator.serviceWorker.register('/sw.js').catch((err) => {

--- a/src/pages/HomeOverview.tsx
+++ b/src/pages/HomeOverview.tsx
@@ -217,7 +217,7 @@ export default function HomeOverview() {
         >
           {/* HERO --------------------------------------------------- */}
           <motion.div variants={item}>
-            <div className="relative overflow-hidden rounded-2xl border border-white/10 bg-gradient-to-br from-emerald-600/40 to-teal-600/40 p-8 text-white shadow-lg backdrop-blur-sm">
+            <div className="hero-gradient relative overflow-hidden rounded-2xl border border-white/15 p-8 text-neutral-100 shadow-lg">
               <div className="grid gap-8 md:grid-cols-2 md:items-center">
                 <div className="flex flex-col items-center gap-4 text-center md:items-start md:text-left">
                   <Logo size="lg" />
@@ -228,11 +228,11 @@ export default function HomeOverview() {
                     <motion.div key={title} variants={item}>
                       <Link
                         to={href}
-                        className="group block rounded-xl border border-white/20 bg-white/10 p-4 transition hover:-translate-y-0.5 hover:ring-2 hover:ring-white/40"
+                        className="glass group block rounded-xl p-4 shadow-sm transition hover:scale-[1.01]"
                       >
-                        <Icon className="mb-2 h-6 w-6" />
-                        <div className="font-medium">{title}</div>
-                        <div className="text-sm text-white/80">{subtitle}</div>
+                        <Icon className="mb-2 h-6 w-6 text-neutral-200" />
+                        <div className="font-medium tracking-wide text-neutral-200">{title}</div>
+                        <div className="text-sm tracking-wide text-neutral-400">{subtitle}</div>
                       </Link>
                     </motion.div>
                   ))}
@@ -569,7 +569,7 @@ export default function HomeOverview() {
         >
           <p className="mb-2 font-semibold">Widget: {activeWidget}</p>
           <button
-            className="mt-2 rounded bg-emerald-600 px-3 py-1 text-sm text-white"
+            className="mt-2 rounded bg-emerald-600 px-3 py-1 text-sm text-neutral-100"
             onClick={() => setActiveWidget(null)}
           >
             Fechar

--- a/src/styles/glass.css
+++ b/src/styles/glass.css
@@ -1,0 +1,19 @@
+.glass {
+  background: rgba(255, 255, 255, 0.08);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
+.dark .glass {
+  background: rgba(255, 255, 255, 0.05);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+}
+
+.hero-gradient {
+  background: linear-gradient(135deg, #009579, #014d46);
+}
+
+.dark .hero-gradient {
+  background: linear-gradient(135deg, #014d46, #002f2a);
+}


### PR DESCRIPTION
## Summary
- add reusable glass and hero-gradient CSS utilities
- apply hero-gradient and glass effects to HomeOverview hero cards
- import glass styles globally

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e17d800fc8322b4220c7dd8e03cec