### PR TITLE
feat: wishlist services, hooks and utilities

### DIFF
--- a/src/hooks/usePriceComparators.ts
+++ b/src/hooks/usePriceComparators.ts
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+
+export interface Offer {
+  source: string;
+  price: number;
+  url: string;
+}
+
+export type CompareQuery = { name?: string; link?: string };
+
+export async function comparePrices(query: CompareQuery): Promise<Offer[]> {
+  const term = query.name ?? query.link ?? '';
+  return [
+    {
+      source: 'Google Shopping',
+      price: 100,
+      url: `https://shopping.google.com/search?q=${encodeURIComponent(term)}`,
+    },
+    {
+      source: 'Mercado Livre',
+      price: 95,
+      url: `https://mercadolivre.com.br/ofertas?search=${encodeURIComponent(term)}`,
+    },
+  ];
+}
+
+export function usePriceComparators() {
+  const [offers, setOffers] = useState<Offer[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const search = async (query: CompareQuery) => {
+    setLoading(true);
+    const res = await comparePrices(query);
+    setOffers(res);
+    setLoading(false);
+  };
+
+  return { offers, loading, search };
+}

--- a/src/hooks/useWishlist.ts
+++ b/src/hooks/useWishlist.ts
@@ -1,0 +1,111 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+import type { FetchWishlistParams, WishlistItem } from '@/services/wishlistApi';
+import { fetchWishlist, recordPricePoint, upsertWishlistItem } from '@/services/wishlistApi';
+import { supabase } from '@/lib/supabaseClient';
+
+export function useWishlist(initialFilters: FetchWishlistParams = {}) {
+  const [items, setItems] = useState<WishlistItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    const data = await fetchWishlist(initialFilters);
+    setItems(data);
+    setLoading(false);
+  }, [initialFilters]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const createItem = async (dto: Omit<WishlistItem, 'id'>) => {
+    const item = await upsertWishlistItem(dto);
+    setItems((prev) => [...prev, item]);
+  };
+
+  const updateItem = async (id: string, changes: Partial<WishlistItem>) => {
+    const item = await upsertWishlistItem({ ...changes, id });
+    setItems((prev) => prev.map((i) => (i.id === id ? item : i)));
+  };
+
+  const deleteItem = async (id: string) => {
+    await supabase.from('wishlist').delete().eq('id', id);
+    setItems((prev) => prev.filter((i) => i.id !== id));
+  };
+
+  const addPricePoint = async (itemId: string, price: number, source?: string) => {
+    const point = await recordPricePoint(itemId, price, source);
+    setItems((prev) =>
+      prev.map((i) =>
+        i.id === itemId
+          ? { ...i, price_points: [...(i.price_points ?? []), point] }
+          : i,
+      ),
+    );
+  };
+
+  const itemsByPriority = useMemo(
+    () => [...items].sort((a, b) => b.priority - a.priority),
+    [items],
+  );
+
+  const itemsOnSale = useMemo(
+    () => items.filter((i) => (i.current_price ?? 0) <= (i.target_price ?? Infinity)),
+    [items],
+  );
+
+  const itemsStale = useMemo(() => {
+    const THIRTY_DAYS = 30 * 24 * 60 * 60 * 1000;
+    return items.filter((i) => {
+      const points = i.price_points ?? [];
+      if (!points.length) return true;
+      const last = points[points.length - 1];
+      if (!last.created_at) return true;
+      return new Date().getTime() - new Date(last.created_at).getTime() > THIRTY_DAYS;
+    });
+  }, [items]);
+
+  const categoryDistribution = useMemo(() => {
+    return items.reduce<Record<string, number>>((acc, item) => {
+      acc[item.category] = (acc[item.category] ?? 0) + 1;
+      return acc;
+    }, {});
+  }, [items]);
+
+  const promoCandidates = useMemo(
+    () => items.filter((i) => i.status === 'pending' && i.priority >= 4),
+    [items],
+  );
+
+  return {
+    items,
+    loading,
+    refresh,
+    createItem,
+    updateItem,
+    deleteItem,
+    addPricePoint,
+    itemsByPriority,
+    itemsOnSale,
+    itemsStale,
+    categoryDistribution,
+    promoCandidates,
+  };
+}
+
+export function simulateMonthlySavings(item: WishlistItem, monthly: number) {
+  const need = (item.target_price ?? 0) - (item.current_price ?? 0);
+  if (monthly <= 0) return Infinity;
+  return Math.max(0, Math.ceil(need / monthly));
+}
+
+export function simulateInstallments(
+  price: number,
+  rates: Array<{ months: number; rate: number }>,
+) {
+  return rates.map((r) => {
+    const total = price * (1 + r.rate * r.months);
+    return { months: r.months, installment: total / r.months, total };
+  });
+}

--- a/src/services/wishlistApi.ts
+++ b/src/services/wishlistApi.ts
@@ -1,0 +1,74 @@
+import { supabase } from '@/lib/supabaseClient';
+
+export interface PricePoint {
+  id?: string;
+  item_id?: string;
+  price: number;
+  source?: string;
+  created_at?: string;
+}
+
+export interface WishlistItem {
+  id: string;
+  name: string;
+  category: string;
+  priority: number;
+  status: string;
+  current_price?: number;
+  target_price?: number;
+  image?: string;
+  link?: string;
+  price_points?: PricePoint[];
+}
+
+export interface FetchWishlistParams {
+  status?: string;
+  category?: string;
+  priority?: number;
+  search?: string;
+}
+
+export async function fetchWishlist(params: FetchWishlistParams = {}): Promise<WishlistItem[]> {
+  let q = supabase.from('wishlist').select('*');
+  if (params.status) q = q.eq('status', params.status);
+  if (params.category) q = q.eq('category', params.category);
+  if (typeof params.priority === 'number') q = q.eq('priority', params.priority);
+  if (params.search) q = q.ilike('name', `%${params.search}%`);
+  const { data, error } = await q.order('priority', { ascending: false });
+  if (error) throw error;
+  return (data || []) as WishlistItem[];
+}
+
+export async function upsertWishlistItem(dto: Partial<WishlistItem>): Promise<WishlistItem> {
+  const { data, error } = await supabase.from('wishlist').upsert(dto).select().single();
+  if (error) throw error;
+  return data as WishlistItem;
+}
+
+export async function recordPricePoint(itemId: string, price: number, source?: string): Promise<PricePoint> {
+  const { data, error } = await supabase
+    .from('wishlist_history')
+    .insert({ item_id: itemId, price, source })
+    .select()
+    .single();
+  if (error) throw error;
+  return data as PricePoint;
+}
+
+export async function getRecentDeals(days: number) {
+  const { data, error } = await supabase.rpc('wishlist_recent_deals', { days });
+  if (error) throw error;
+  return data as unknown[];
+}
+
+export async function getWishlistProgress() {
+  const { data, error } = await supabase.rpc('wishlist_progress');
+  if (error) throw error;
+  return data as unknown;
+}
+
+export async function moveToShoppingList(args: { item_id: string; quantity?: number }) {
+  const { data, error } = await supabase.rpc('wishlist_move_to_shopping', args);
+  if (error) throw error;
+  return data as unknown;
+}

--- a/src/utils/forecast.ts
+++ b/src/utils/forecast.ts
@@ -1,0 +1,37 @@
+/**
+ * Simple moving average for a series of numbers.
+ */
+export function simpleMovingAverage(points: number[], window: number) {
+  const out: number[] = [];
+  for (let i = 0; i < points.length; i++) {
+    const start = Math.max(0, i - window + 1);
+    const slice = points.slice(start, i + 1);
+    const avg = slice.reduce((s, v) => s + v, 0) / (slice.length || 1);
+    out.push(avg);
+  }
+  return out;
+}
+
+/**
+ * Exponential moving average for a series.
+ */
+export function exponentialMovingAverage(points: number[], alpha: number) {
+  const out: number[] = [];
+  points.forEach((p, idx) => {
+    if (idx === 0) out.push(p);
+    else out.push(alpha * p + (1 - alpha) * out[idx - 1]);
+  });
+  return out;
+}
+
+/**
+ * Indicates if the latest price is below the EMA of previous values,
+ * suggesting a possible price drop and a good moment to buy.
+ */
+export function priceDropLikely(history: number[]) {
+  if (history.length < 2) return false;
+  const ema = exponentialMovingAverage(history.slice(0, -1), 0.3);
+  const last = history[history.length - 1];
+  const prev = ema[ema.length - 1];
+  return last < prev;
+}

--- a/src/utils/pdf-wishlist.ts
+++ b/src/utils/pdf-wishlist.ts
@@ -1,0 +1,74 @@
+import jsPDF from 'jspdf';
+import autoTable from 'jspdf-autotable';
+
+import type { WishlistItem } from '@/services/wishlistApi';
+
+async function fetchImageAsDataUrl(url: string) {
+  if (!url) return null;
+  try {
+    const res = await fetch(url);
+    const blob = await res.blob();
+    return await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result as string);
+      reader.onerror = () => reject(new Error('fail'));
+      reader.readAsDataURL(blob);
+    });
+  } catch {
+    return null;
+  }
+}
+
+export async function exportWishlistPDF(items: WishlistItem[]) {
+  const doc = new jsPDF();
+  const rows: Array<{
+    img: string | null;
+    name: string;
+    current: string;
+    target: string;
+    progress: string;
+    link: string;
+  }> = [];
+
+  for (const item of items) {
+    const img = await fetchImageAsDataUrl(item.image ?? '');
+    const current = (item.current_price ?? 0).toLocaleString('pt-BR', {
+      style: 'currency',
+      currency: 'BRL',
+    });
+    const target = (item.target_price ?? 0).toLocaleString('pt-BR', {
+      style: 'currency',
+      currency: 'BRL',
+    });
+    const progress =
+      item.current_price && item.target_price
+        ? `${Math.min(
+            100,
+            Math.round((item.current_price / item.target_price) * 100),
+          )}%`
+        : '-';
+    rows.push({
+      img,
+      name: item.name,
+      current,
+      target,
+      progress,
+      link: item.link ?? '',
+    });
+  }
+
+  autoTable(doc, {
+    head: [['', 'Item', 'Atual', 'Meta', 'Progresso', 'Link']],
+    body: rows.map((r) => ['', r.name, r.current, r.target, r.progress, r.link]),
+    didDrawCell: (data) => {
+      if (data.section === 'body' && data.column.index === 0) {
+        const row = rows[data.row.index];
+        if (row.img) {
+          doc.addImage(row.img, 'PNG', data.cell.x + 2, data.cell.y + 2, 16, 16);
+        }
+      }
+    },
+  });
+
+  doc.save('wishlist.pdf');
+}


### PR DESCRIPTION
## Summary
- add wishlist API services and hook with history, deals, progress and simulations
- stub price comparator hook for Google Shopping and Mercado Livre
- provide wishlist PDF export and forecasting helpers

## Testing
- `npm run lint && npm run typecheck`
- `npx tsx -e "import('./src/services/wishlistApi.ts').then(async m => { try { await m.fetchWishlist(); await m.getRecentDeals(7); console.log('done'); } catch (e) { console.error('error', e?.message || e); } })"`


------
https://chatgpt.com/codex/tasks/task_e_689e2477f2608322a90669e6f5fa897f