### PR TITLE
feat: restore top navigation

### DIFF
--- a/src/components/TopNav.tsx
+++ b/src/components/TopNav.tsx
@@ -1,0 +1,113 @@
+import * as React from 'react';
+import { NavLink, useLocation, useNavigate } from 'react-router-dom';
+import { ChevronDown, Settings } from 'lucide-react';
+
+import AlertsDrawer from './financas/AlertsDrawer';
+import { ThemeToggle } from './ui/ThemeToggle';
+import { Logo } from './Logo';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from './ui/dropdown-menu';
+
+import { useAuth } from '@/contexts/AuthContext';
+import {
+  dashboardNavItem,
+  navGroups,
+  getNavItem,
+} from '@/routes/nav';
+
+const activeLink =
+  'text-white font-semibold ring-1 ring-white/30 rounded-lg px-3 py-1 bg-white/10';
+const baseLink =
+  'text-white/80 hover:text-white px-3 py-1 rounded-lg transition';
+
+export default function TopNav() {
+  const location = useLocation();
+  const navigate = useNavigate();
+  const { user, signOut } = useAuth();
+  const initials = user?.email?.slice(0, 2).toUpperCase() ?? '';
+
+  const activeItem = getNavItem(location.pathname);
+
+  return (
+    <header className="topbar-glass sticky top-0 z-50 border-b border-white/10 bg-gradient-to-r from-emerald-600/80 to-teal-600/80 backdrop-blur">
+      <div className="mx-auto flex h-16 items-center px-4">
+        <NavLink to={dashboardNavItem.to} className="flex items-center text-white">
+          <Logo size="lg" />
+          <span className="ml-2 text-xl font-semibold">FY</span>
+        </NavLink>
+        <nav className="ml-6 flex items-center gap-2">
+          <NavLink
+            to={dashboardNavItem.to}
+            className={({ isActive }) => (isActive ? activeLink : baseLink)}
+          >
+            {dashboardNavItem.label}
+          </NavLink>
+          {navGroups.map((group) => {
+            const isActive = group.items.some((it) => it.to === activeItem?.to);
+            return (
+              <DropdownMenu key={group.label}>
+                <DropdownMenuTrigger asChild>
+                  <button
+                    className={`${isActive ? activeLink : baseLink} flex items-center gap-1`}
+                  >
+                    {group.label}
+                    <ChevronDown className="h-4 w-4" />
+                  </button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="start">
+                  {group.items.map((it) => (
+                    <DropdownMenuItem
+                      key={it.to}
+                      onSelect={() => navigate(it.to)}
+                    >
+                      {it.label}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
+            );
+          })}
+        </nav>
+        <div className="ml-auto flex items-center gap-2">
+          <AlertsDrawer />
+          <ThemeToggle />
+          <NavLink
+            to="/configuracoes"
+            className="inline-flex h-9 w-9 items-center justify-center rounded-xl text-white hover:bg-white/20"
+            title="Configurações"
+          >
+            <Settings className="h-4 w-4" />
+          </NavLink>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button className="flex items-center gap-2 rounded-xl px-2 py-1 text-white hover:bg-white/20">
+                <div className="flex h-9 w-9 items-center justify-center rounded-full bg-emerald-500 text-sm font-semibold">
+                  {initials}
+                </div>
+                <div className="hidden md:flex min-w-0 flex-col text-left">
+                  <span className="truncate text-sm font-medium">
+                    {user?.user_metadata?.full_name || user?.email}
+                  </span>
+                  <span className="truncate text-xs text-white/80">{user?.email}</span>
+                </div>
+                <ChevronDown className="h-4 w-4" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-40">
+              <DropdownMenuItem onSelect={() => navigate('/perfil')}>
+                Perfil
+              </DropdownMenuItem>
+              <DropdownMenuItem onSelect={signOut}>Sair</DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+    </header>
+  );
+}
+
+export { dashboardNavItem, navGroups, getNavItem };

--- a/src/routes/nav.ts
+++ b/src/routes/nav.ts
@@ -1,11 +1,64 @@
-export interface NavRoute {
+export interface NavItem {
   label: string;
   to: string;
+}
+
+export interface NavRoute extends NavItem {
   variant?: 'pill' | 'ghost';
 }
 
+export const dashboardNavItem: NavItem = {
+  label: 'Visão geral',
+  to: '/dashboard',
+};
+
+export interface NavGroup {
+  label: string;
+  items: NavItem[];
+}
+
+export const navGroups: NavGroup[] = [
+  {
+    label: 'Finanças',
+    items: [
+      { label: 'Resumo', to: '/financas/resumo' },
+      { label: 'Mensal', to: '/financas/mensal' },
+      { label: 'Anual', to: '/financas/anual' },
+    ],
+  },
+  {
+    label: 'Investimentos',
+    items: [
+      { label: 'Resumo', to: '/investimentos/resumo' },
+      { label: 'Carteira', to: '/investimentos/carteira' },
+      { label: 'Renda Fixa', to: '/investimentos/renda-fixa' },
+      { label: 'FIIs', to: '/investimentos/fiis' },
+      { label: 'Bolsa', to: '/investimentos/bolsa' },
+      { label: 'Cripto', to: '/investimentos/cripto' },
+    ],
+  },
+  {
+    label: 'Planejamento',
+    items: [
+      { label: 'Metas & Projetos', to: '/metas' },
+      { label: 'Milhas', to: '/milhas' },
+      { label: 'Desejos', to: '/desejos' },
+      { label: 'Compras', to: '/compras' },
+    ],
+  },
+];
+
+export function getNavItem(pathname: string): NavItem | null {
+  if (pathname.startsWith(dashboardNavItem.to)) return dashboardNavItem;
+  for (const group of navGroups) {
+    const item = group.items.find((it) => pathname.startsWith(it.to));
+    if (item) return item;
+  }
+  return null;
+}
+
 export const navRoutes: NavRoute[] = [
-  { label: 'Visão geral', to: '/dashboard', variant: 'pill' },
+  { ...dashboardNavItem, variant: 'pill' },
   { label: 'Finanças', to: '/financas/resumo' },
   { label: 'Investimentos', to: '/investimentos/resumo' },
   { label: 'Metas & Projetos', to: '/metas' },
@@ -13,3 +66,5 @@ export const navRoutes: NavRoute[] = [
   { label: 'Desejos', to: '/desejos' },
   { label: 'Compras', to: '/compras' },
 ];
+
+export type { NavGroup as TopNavGroup };


### PR DESCRIPTION
## Summary
- restore and modernize TopNav component based on AppTopbar implementation
- centralize navigation metadata and helpers for reuse

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: Cannot find name 'forecastLoading', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689e25b631c0832293067505471a981e