### PR TITLE
refactor: update dashboard route to homeoverview

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,7 +12,7 @@ import { PeriodProvider } from '@/contexts/PeriodContext';
 /* ---------- lazy imports de páginas ---------- */
 const FinancasResumo = lazy(() => import('./pages/FinancasResumo'));
 // Visão geral com cartões-resumo dos módulos
-const Dashboard      = lazy(() => import('./pages/HomeOverview'));
+const HomeOverview   = lazy(() => import('./pages/HomeOverview'));
 const FinancasMensal = lazy(() => import('./pages/FinancasMensal'));
 const FinancasAnual  = lazy(() => import('./pages/FinancasAnual'));
 
@@ -82,10 +82,10 @@ function AppRoutes() {
       <Suspense fallback={<RouteLoader />}>
 
         <Routes>
-            {/* Dashboard */}
-            <Route path="/dashboard" element={<Dashboard />} />
-            <Route path="/home" element={<Navigate to="/dashboard" replace />} />
-            <Route path="/" element={<Navigate to="/dashboard" replace />} />
+            {/* Home overview */}
+            <Route path="/homeoverview" element={<HomeOverview />} />
+            <Route path="/home" element={<Navigate to="/homeoverview" replace />} />
+            <Route path="/" element={<Navigate to="/homeoverview" replace />} />
 
             {/* Finanças */}
             <Route path="/financas/resumo" element={<FinancasResumo />} />

--- a/src/components/AppHotkeys.tsx
+++ b/src/components/AppHotkeys.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 
 const map: Record<string, string> = {
-  d: "/dashboard",
+  d: "/homeoverview",
   f: "/financas/mensal",
   i: "/investimentos/resumo",
   m: "/metas",

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -35,7 +35,7 @@ type Section = { label: string; items: (NavLeaf | NavGroup)[] };
 const sections: Section[] = [
   {
     label: "Geral",
-    items: [{ type: "item", label: "Visão geral", to: "/dashboard", icon: LayoutDashboard }],
+    items: [{ type: "item", label: "Visão geral", to: "/homeoverview", icon: LayoutDashboard }],
   },
   {
     label: "Finanças",
@@ -307,7 +307,7 @@ function NavLeafLink({ leaf, collapsed }: { leaf: NavLeaf; collapsed?: boolean }
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/40",
           collapsed ? "justify-center" : "",
           isActive
-            ? leaf.to === "/dashboard"
+            ? leaf.to === "/homeoverview"
               ? "sb-active bg-gradient-to-r from-emerald-600/20 to-emerald-400/20 text-emerald-200 ring-2 ring-emerald-400/60"
               : "sb-active bg-emerald-500/15 text-emerald-300 ring-1 ring-emerald-500/30"
             : "text-slate-300 hover:text-white hover:bg-emerald-600/10",

--- a/src/components/layout/NavMenu.tsx
+++ b/src/components/layout/NavMenu.tsx
@@ -34,7 +34,7 @@ export interface NavMenuItem {
 }
 
 export const defaultNavItems: NavMenuItem[] = [
-  { label: "Visão geral", icon: LayoutDashboard, to: "/dashboard" },
+  { label: "Visão geral", icon: LayoutDashboard, to: "/homeoverview" },
   {
     label: "Finanças",
     icon: WalletCards,

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -16,7 +16,7 @@ export default function Topbar() {
     <header className="topbar-glass sticky top-0 z-50 border-b border-white/10 bg-gradient-to-r from-emerald-600/80 to-teal-600/80 backdrop-blur">
       <div className="mx-auto flex h-16 items-center px-4">
         <NavLink
-          to="/dashboard"
+          to="/homeoverview"
           className="flex items-center text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 rounded"
         >
           <Logo size="lg" />

--- a/src/routes/nav.ts
+++ b/src/routes/nav.ts
@@ -5,7 +5,7 @@ export interface NavRoute {
 }
 
 export const navRoutes: NavRoute[] = [
-  { label: 'Visão geral', to: '/dashboard', variant: 'pill' },
+  { label: 'Visão geral', to: '/homeoverview', variant: 'pill' },
   { label: 'Finanças', to: '/financas/resumo' },
   { label: 'Investimentos', to: '/investimentos/resumo' },
   { label: 'Metas & Projetos', to: '/metas' },


### PR DESCRIPTION
## Summary
- replace `/dashboard` routes with `/homeoverview`
- adjust navigation components and hotkeys for new path

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: Cannot find name 'Target', and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e26a823b88322b56678bd8661422a