### PR TITLE
fix: ensure consistent AppShell padding

### DIFF
--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -6,32 +6,10 @@ interface AppShellProps {
 }
 
 export default function AppShell({ topbar, children }: AppShellProps) {
-  const topbarRef = React.useRef<HTMLDivElement>(null);
-  const [paddingTop, setPaddingTop] = React.useState(0);
-
-  React.useEffect(() => {
-    const el = topbarRef.current;
-    if (!el) return;
-
-    const update = () => setPaddingTop(el.offsetHeight);
-    update();
-
-    const observer = new ResizeObserver(update);
-    observer.observe(el);
-    window.addEventListener('resize', update);
-
-    return () => {
-      observer.disconnect();
-      window.removeEventListener('resize', update);
-    };
-  }, []);
-
   return (
     <div className="min-h-screen">
-      {topbar && <div ref={topbarRef}>{topbar}</div>}
-      <main className="p-6" style={{ paddingTop }}>
-        {children}
-      </main>
+      {topbar}
+      <main className="p-6 pt-16 md:pt-20">{children}</main>
     </div>
   );
 }

--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from "react";
+import type { PropsWithChildren } from "react";
 
 import Topbar from "@/components/layout/Topbar";
 import { cn } from "@/lib/utils";
@@ -11,7 +11,7 @@ export default function AppShell({ children, mainClassName }: AppShellProps) {
   return (
     <>
       <Topbar />
-      <main className={cn("pt-20", mainClassName)}>{children}</main>
+      <main className={cn("p-6 pt-16 md:pt-20", mainClassName)}>{children}</main>
     </>
   );
 }

--- a/src/pages/Investimentos.tsx
+++ b/src/pages/Investimentos.tsx
@@ -80,7 +80,7 @@ export default function InvestimentosResumo() {
   const latest = useMemo(() => rows.slice(0, 10), [rows]);
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 pb-24">
       <PageHeader
         title="Investimentos — Resumo"
         subtitle="Visão geral dos seus aportes por classe de ativos. Crie e edite nas páginas de Carteira."

--- a/src/pages/Metas.tsx
+++ b/src/pages/Metas.tsx
@@ -360,23 +360,24 @@ export default function Metas() {
   /* ------------------------------ UI ------------------------------ */
   return (
     <>
-      <PageHeader
-        title="Metas & Projetos"
-        subtitle="Defina objetivos, acompanhe progresso, registre aportes e mantenha tudo sob controle."
-        icon={<Target className="h-5 w-5" />}
-        actions={
-          <Button
-            onClick={openNewGoal}
-            className="gap-2 bg-emerald-600 hover:bg-emerald-500 text-white"
-          >
-            <Plus className="h-4 w-4" />
-            Nova meta
-          </Button>
-        }
-      />
+      <div className="space-y-6 pb-24">
+        <PageHeader
+          title="Metas & Projetos"
+          subtitle="Defina objetivos, acompanhe progresso, registre aportes e mantenha tudo sob controle."
+          icon={<Target className="h-5 w-5" />}
+          actions={
+            <Button
+              onClick={openNewGoal}
+              className="gap-2 bg-emerald-600 hover:bg-emerald-500 text-white"
+            >
+              <Plus className="h-4 w-4" />
+              Nova meta
+            </Button>
+          }
+        />
 
-      {/* KPIs */}
-      <div className="grid gap-4 md:grid-cols-4">
+        {/* KPIs */}
+        <div className="grid gap-4 md:grid-cols-4">
         <Card className="shadow-sm">
           <CardHeader className="pb-2">
             <CardDescription>Patrimônio alvo</CardDescription>
@@ -534,6 +535,7 @@ export default function Metas() {
               </CardFooter>
             </Card>
           ))}
+        </div>
       </div>
 
       {/* Dialog Nova/Editar Meta */}

--- a/src/pages/MilhasHome.tsx
+++ b/src/pages/MilhasHome.tsx
@@ -14,7 +14,7 @@ export default function MilhasHome() {
   ];
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-6 pb-24">
       <PageHeader
         title="Milhas"
         subtitle="Resumo geral e atalhos para programas"


### PR DESCRIPTION
## Summary
- add responsive top padding to AppShell components
- add bottom padding to Investimentos, Metas, and Milhas pages

## Testing
- `npm run lint`
- `npm run typecheck`
- `npm run build` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_689e26a9ea408322afb3dfbca4f7258d