### PR TITLE
feat: add card components to HomeOverview

### DIFF
--- a/src/pages/HomeOverview.tsx
+++ b/src/pages/HomeOverview.tsx
@@ -32,14 +32,15 @@ import AlertsDrawer from "@/components/dashboard/AlertsDrawer";
 import RecurrenceWidget from "@/components/dashboard/RecurrenceWidget";
 import AlertList from "@/components/dashboard/AlertList";
 import InsightCard from "@/components/dashboard/InsightCard";
-import { KpiCard } from "@/components/dashboard/KPIStrip";
 import {
   WidgetCard,
   WidgetFooterAction,
   WidgetHeader,
 } from "@/components/dashboard/WidgetCard";
 import { useRecurrences } from "@/hooks/useRecurrences";
+import { useInsights } from "@/hooks/useInsights";
 import { EmptyState } from "@/components/ui/EmptyState";
+import { Card, CardHeader } from "@/components/ui/card";
 import { formatCurrency } from "@/lib/utils";
 import { usePeriod } from "@/state/periodFilter";
 import { KpiCard } from "@/components/financas";


### PR DESCRIPTION
## Summary
- add Card and CardHeader import in HomeOverview
- ensure insights hook imported and clean up duplicate KPI import

## Testing
- `npm run lint`
- `npm run typecheck` *(passes)*
- `npm run build` *(fails: Cannot find name 'forecastLoading', 'ComposedChart', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_689e26ac0a88832290538f97709dd9a2