### PR TITLE
feat: add wishlist modals and drawer

### DIFF
--- a/src/components/wishlist/WishlistDrawer.tsx
+++ b/src/components/wishlist/WishlistDrawer.tsx
@@ -1,0 +1,84 @@
+import * as React from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { LineChart, Line, XAxis, YAxis, Tooltip, ResponsiveContainer } from "recharts";
+
+import type { WishlistItem } from "./WishlistNewItemModal";
+
+interface Props {
+  item: WishlistItem | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function WishlistDrawer({ item, open, onOpenChange }: Props) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 bg-black/40" />
+        <Dialog.Content className="fixed right-0 top-0 h-full w-80 bg-background p-4 shadow-xl overflow-auto">
+          {item && (
+            <div className="space-y-4">
+              <div className="flex items-center space-x-2">
+                {item.imagem && (
+                  <img src={item.imagem} alt="" className="h-16 w-16 object-cover rounded" />
+                )}
+                <div>
+                  <h2 className="text-lg font-semibold leading-tight line-clamp-2">
+                    {item.titulo}
+                  </h2>
+                  <p className="text-sm text-muted-foreground">{item.vendedor}</p>
+                </div>
+              </div>
+              <div className="h-40">
+                {item.historico && item.historico.length > 0 ? (
+                  <ResponsiveContainer width="100%" height="100%">
+                    <LineChart data={item.historico} margin={{ top: 4, right: 8, bottom: 4, left: 8 }}>
+                      <XAxis dataKey="data" hide />
+                      <YAxis hide domain={['dataMin', 'dataMax']} />
+                      <Tooltip />
+                      <Line type="monotone" dataKey="preco" stroke="#10b981" strokeWidth={2} dot={false} />
+                    </LineChart>
+                  </ResponsiveContainer>
+                ) : (
+                  <p className="text-sm text-muted-foreground">Sem histórico de preço.</p>
+                )}
+              </div>
+              {item.notas && (
+                <div>
+                  <h3 className="font-medium">Notas</h3>
+                  <p className="text-sm whitespace-pre-wrap">{item.notas}</p>
+                </div>
+              )}
+              <div>
+                <h3 className="font-medium">Link</h3>
+                <a href={item.link} target="_blank" rel="noopener noreferrer" className="text-sm text-emerald-700 hover:underline">
+                  {item.link}
+                </a>
+              </div>
+              {item.ofertas && item.ofertas.length > 0 && (
+                <div>
+                  <h3 className="font-medium">Ofertas comparadas</h3>
+                  <ul className="mt-2 space-y-1 text-sm">
+                    {item.ofertas.map((o, idx) => (
+                      <li key={idx}>
+                        <a
+                          href={o.link}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-emerald-700 hover:underline"
+                        >
+                          {o.vendedor}: R$ {o.preco.toFixed(2)}
+                        </a>
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+

--- a/src/components/wishlist/WishlistNewItemModal.tsx
+++ b/src/components/wishlist/WishlistNewItemModal.tsx
@@ -1,0 +1,187 @@
+import * as React from "react";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { Switch } from "@/components/ui/switch";
+
+export type WishlistItem = {
+  id: string;
+  titulo: string;
+  link: string;
+  vendedor: string;
+  categoria: string;
+  prioridade: string;
+  precoAlvo: number;
+  precoAtual: number;
+  imagem: string;
+  notas: string;
+  alertas: boolean;
+  historico?: { data: string; preco: number }[];
+  ofertas?: { vendedor: string; preco: number; link: string }[];
+};
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onCreated: (item: WishlistItem) => void;
+}
+
+const CATEGORIAS = ["Eletrônicos", "Livros", "Casa", "Outros"];
+const PRIORIDADES = ["Alta", "Média", "Baixa"];
+
+export default function WishlistNewItemModal({ open, onOpenChange, onCreated }: Props) {
+  const [titulo, setTitulo] = React.useState("");
+  const [link, setLink] = React.useState("");
+  const [vendedor, setVendedor] = React.useState("");
+  const [categoria, setCategoria] = React.useState<string>(CATEGORIAS[0]);
+  const [prioridade, setPrioridade] = React.useState<string>(PRIORIDADES[0]);
+  const [precoAlvo, setPrecoAlvo] = React.useState(0);
+  const [precoAtual, setPrecoAtual] = React.useState(0);
+  const [imagem, setImagem] = React.useState("");
+  const [notas, setNotas] = React.useState("");
+  const [alertas, setAlertas] = React.useState(true);
+
+  React.useEffect(() => {
+    if (open) {
+      setTitulo("");
+      setLink("");
+      setVendedor("");
+      setCategoria(CATEGORIAS[0]);
+      setPrioridade(PRIORIDADES[0]);
+      setPrecoAlvo(0);
+      setPrecoAtual(0);
+      setImagem("");
+      setNotas("");
+      setAlertas(true);
+    }
+  }, [open]);
+
+  const handleSalvar = (e: React.FormEvent) => {
+    e.preventDefault();
+    const item: WishlistItem = {
+      id: crypto.randomUUID(),
+      titulo,
+      link,
+      vendedor,
+      categoria,
+      prioridade,
+      precoAlvo,
+      precoAtual,
+      imagem,
+      notas,
+      alertas,
+    };
+    onCreated(item);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Novo desejo</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSalvar} className="flex flex-col gap-4 mt-2">
+          <div>
+            <label className="block text-sm font-medium mb-1">Título</label>
+            <Input value={titulo} onChange={e => setTitulo(e.target.value)} required />
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className="block text-sm font-medium mb-1">Link</label>
+              <Input value={link} onChange={e => setLink(e.target.value)} />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Vendedor</label>
+              <Input value={vendedor} onChange={e => setVendedor(e.target.value)} />
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className="block text-sm font-medium mb-1">Categoria</label>
+              <Select value={categoria} onValueChange={setCategoria}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {CATEGORIAS.map(c => (
+                    <SelectItem key={c} value={c}>
+                      {c}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Prioridade</label>
+              <Select value={prioridade} onValueChange={setPrioridade}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {PRIORIDADES.map(p => (
+                    <SelectItem key={p} value={p}>
+                      {p}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          </div>
+          <div className="grid grid-cols-2 gap-2">
+            <div>
+              <label className="block text-sm font-medium mb-1">Preço alvo</label>
+              <Input
+                type="number"
+                value={precoAlvo}
+                onChange={e => setPrecoAlvo(Number(e.target.value))}
+                min={0}
+                step="0.01"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium mb-1">Preço atual</label>
+              <Input
+                type="number"
+                value={precoAtual}
+                onChange={e => setPrecoAtual(Number(e.target.value))}
+                min={0}
+                step="0.01"
+              />
+            </div>
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Imagem (URL)</label>
+            <Input value={imagem} onChange={e => setImagem(e.target.value)} />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Notas</label>
+            <Textarea value={notas} onChange={e => setNotas(e.target.value)} rows={3} />
+          </div>
+          <div className="flex items-center space-x-2">
+            <Switch checked={alertas} onCheckedChange={setAlertas} id="alertas" />
+            <label htmlFor="alertas" className="text-sm font-medium">
+              Alertas de preço
+            </label>
+          </div>
+          <DialogFooter className="mt-2">
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={!titulo.trim()}>Salvar</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/components/wishlist/WishlistSimulateModal.tsx
+++ b/src/components/wishlist/WishlistSimulateModal.tsx
@@ -1,0 +1,66 @@
+import * as React from "react";
+
+import type { WishlistItem } from "./WishlistNewItemModal";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface Props {
+  item: WishlistItem | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function WishlistSimulateModal({ item, open, onOpenChange }: Props) {
+  const [mensal, setMensal] = React.useState(0);
+  const restante = item ? Math.max(item.precoAlvo - item.precoAtual, 0) : 0;
+  const meses = mensal > 0 ? Math.ceil(restante / mensal) : 0;
+
+  React.useEffect(() => {
+    if (open) setMensal(0);
+  }, [open]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>Simular poupança</DialogTitle>
+        </DialogHeader>
+        {item ? (
+          <div className="space-y-4 mt-2">
+            <p className="text-sm">Item: <strong>{item.titulo}</strong></p>
+            <div>
+              <label className="block text-sm font-medium mb-1">Aporte mensal</label>
+              <Input
+                type="number"
+                value={mensal}
+                onChange={e => setMensal(Number(e.target.value))}
+                min={0}
+                step="0.01"
+                autoFocus
+              />
+            </div>
+            {mensal > 0 && (
+              <p className="text-sm">
+                Você atingirá o alvo em <strong>{meses}</strong> {meses === 1 ? 'mês' : 'meses'}.
+              </p>
+            )}
+          </div>
+        ) : null}
+        <DialogFooter className="mt-2">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Fechar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/pages/ListaDesejos.tsx
+++ b/src/pages/ListaDesejos.tsx
@@ -1,3 +1,84 @@
+import * as React from "react";
+
+import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import WishlistNewItemModal, { WishlistItem } from "@/components/wishlist/WishlistNewItemModal";
+import WishlistSimulateModal from "@/components/wishlist/WishlistSimulateModal";
+import WishlistDrawer from "@/components/wishlist/WishlistDrawer";
+
 export default function Desejos() {
-  return <h1 className="text-2xl font-bold">🛍️ Desejos</h1>;
+  const [items, setItems] = React.useState<WishlistItem[]>([
+    {
+      id: "1",
+      titulo: "Nintendo Switch",
+      link: "https://example.com/switch",
+      vendedor: "Loja X",
+      categoria: "Eletrônicos",
+      prioridade: "Alta",
+      precoAlvo: 2000,
+      precoAtual: 1500,
+      imagem: "https://via.placeholder.com/150",
+      notas: "Aguardar promoção",
+      alertas: true,
+      historico: [
+        { data: "Jan", preco: 2500 },
+        { data: "Fev", preco: 2300 },
+        { data: "Mar", preco: 2100 },
+        { data: "Abr", preco: 1900 },
+      ],
+      ofertas: [
+        { vendedor: "Loja Y", preco: 1550, link: "https://example.com/oferta1" },
+        { vendedor: "Loja Z", preco: 1600, link: "https://example.com/oferta2" },
+      ],
+    },
+  ]);
+  const [newOpen, setNewOpen] = React.useState(false);
+  const [simulateItem, setSimulateItem] = React.useState<WishlistItem | null>(null);
+  const [simulateOpen, setSimulateOpen] = React.useState(false);
+  const [drawerItem, setDrawerItem] = React.useState<WishlistItem | null>(null);
+  const [drawerOpen, setDrawerOpen] = React.useState(false);
+
+  const handleCreated = (item: WishlistItem) => {
+    setItems(prev => [...prev, item]);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">🛍️ Desejos</h1>
+        <Button onClick={() => setNewOpen(true)}>Novo desejo</Button>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        {items.map(item => (
+          <Card
+            key={item.id}
+            onMouseEnter={() => {
+              setDrawerItem(item);
+              setDrawerOpen(true);
+            }}
+          >
+            <CardHeader className="pb-2">
+              <CardTitle className="text-base line-clamp-1">{item.titulo}</CardTitle>
+            </CardHeader>
+            <CardContent className="flex flex-col items-center">
+              {item.imagem && (
+                <img src={item.imagem} alt="" className="h-32 w-full object-cover rounded" />
+              )}
+              <p className="mt-2 text-sm">Atual: R$ {item.precoAtual.toFixed(2)}</p>
+              <p className="text-sm">Alvo: R$ {item.precoAlvo.toFixed(2)}</p>
+            </CardContent>
+            <CardFooter>
+              <Button size="sm" onClick={() => { setSimulateItem(item); setSimulateOpen(true); }}>
+                Simular
+              </Button>
+            </CardFooter>
+          </Card>
+        ))}
+      </div>
+      <WishlistNewItemModal open={newOpen} onOpenChange={setNewOpen} onCreated={handleCreated} />
+      <WishlistSimulateModal item={simulateItem} open={simulateOpen} onOpenChange={setSimulateOpen} />
+      <WishlistDrawer item={drawerItem} open={drawerOpen} onOpenChange={setDrawerOpen} />
+    </div>
+  );
 }
+


### PR DESCRIPTION
## Summary
- add modal to create wishlist items with price alerts and metadata
- add simulation modal to estimate months until target price
- add drawer showing price history, notes and alternative offers
- wire wishlist page with new modals and drawer

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e4f0938e0832291090df3c1673950