### PR TITLE
feat: add glassmorphism and motion to UI

### DIFF
--- a/src/components/dashboard/WidgetCard.tsx
+++ b/src/components/dashboard/WidgetCard.tsx
@@ -1,10 +1,21 @@
 import { ChevronRight } from "lucide-react";
+import { motion } from "framer-motion";
 import type { PropsWithChildren } from "react";
 import { Link } from "react-router-dom";
 
 // Generic card used by dashboard widgets.
 export function WidgetCard({ className, children }: PropsWithChildren<{ className?: string }>) {
-  return <div className={`card-surface p-5 sm:p-6 ${className ?? ""}`}>{children}</div>;
+  return (
+    <motion.div
+      className={`card-surface p-5 sm:p-6 ${className ?? ""}`}
+      initial={{ opacity: 0, y: 16 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: -16 }}
+      whileHover={{ y: -4 }}
+    >
+      {children}
+    </motion.div>
+  );
 }
 
 export function WidgetHeader({ title, subtitle }: { title: string; subtitle?: string }) {

--- a/src/components/layout/MobileNavDrawer.tsx
+++ b/src/components/layout/MobileNavDrawer.tsx
@@ -52,7 +52,7 @@ export default function MobileNavDrawer() {
                   animate={{ x: 0 }}
                   exit={{ x: "-100%" }}
                   transition={{ type: "spring", stiffness: 300, damping: 30 }}
-                  className="fixed left-0 top-0 z-50 flex h-full w-72 flex-col bg-background/80 backdrop-blur-xl shadow-xl"
+                  className="fixed left-0 top-0 z-50 flex h-full w-72 flex-col rounded-r-2xl border-r border-white/40 bg-white/70 backdrop-blur shadow-xl dark:border-white/10 dark:bg-white/5"
                 >
                   <nav className="flex-1 overflow-y-auto p-4 space-y-2">
                     {defaultNavItems.map((item) => {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow",
+      "rounded-2xl border border-white/40 bg-white/70 text-card-foreground shadow-sm backdrop-blur dark:border-white/10 dark:bg-white/5",
       className
     )}
     {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,6 +1,7 @@
 import * as React from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import { X } from "lucide-react"
+import { motion } from "framer-motion"
 
 import { cn } from "@/lib/utils"
 
@@ -12,20 +13,24 @@ const DialogPortal = DialogPrimitive.Portal
 
 const DialogClose = DialogPrimitive.Close
 
+const MotionOverlay = motion(DialogPrimitive.Overlay)
+
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
 >(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
+  <MotionOverlay
     ref={ref}
-    className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-      className
-    )}
+    className={cn("fixed inset-0 z-50 bg-black/40 backdrop-blur-sm", className)}
+    initial={{ opacity: 0 }}
+    animate={{ opacity: 1 }}
+    exit={{ opacity: 0 }}
     {...props}
   />
 ))
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const MotionContent = motion(DialogPrimitive.Content)
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
@@ -33,21 +38,24 @@ const DialogContent = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <DialogPortal>
     <DialogOverlay />
-    <DialogPrimitive.Content
+    <MotionContent
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl p-6 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%]",
-        "bg-background/75 backdrop-blur supports-[backdrop-filter]:border",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border border-white/40 bg-white/70 p-6 shadow-2xl backdrop-blur dark:border-white/10 dark:bg-white/5",
         className
       )}
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 0.95 }}
+      transition={{ duration: 0.2 }}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
+    </MotionContent>
   </DialogPortal>
 ))
 DialogContent.displayName = DialogPrimitive.Content.displayName

--- a/src/pages/ListaDesejos.tsx
+++ b/src/pages/ListaDesejos.tsx
@@ -1,3 +1,35 @@
+import { Star, TrendingDown, Target, ShoppingBag } from "lucide-react";
+import { motion } from "framer-motion";
+
+import { Card } from "@/components/ui/card";
+
+const items = [
+  { icon: Star, label: "Favoritos" },
+  { icon: TrendingDown, label: "Promoções" },
+  { icon: Target, label: "Metas" },
+  { icon: ShoppingBag, label: "Compras" },
+];
+
 export default function Desejos() {
-  return <h1 className="text-2xl font-bold">🛍️ Desejos</h1>;
+  return (
+    <div className="space-y-6">
+      <h1 className="text-2xl font-bold">🛍️ Desejos</h1>
+      <div className="grid gap-4 sm:grid-cols-2">
+        {items.map((item, i) => (
+          <motion.div
+            key={item.label}
+            initial={{ opacity: 0, y: 12 }}
+            animate={{ opacity: 1, y: 0 }}
+            transition={{ delay: i * 0.05 }}
+          >
+            <Card className="flex items-center gap-3 p-4">
+              <item.icon className="h-5 w-5" />
+              <span>{item.label}</span>
+            </Card>
+          </motion.div>
+        ))}
+      </div>
+    </div>
+  );
 }
+

--- a/src/styles/glass.css
+++ b/src/styles/glass.css
@@ -1,13 +1,20 @@
+:root {
+  --glass-bg: rgba(255, 255, 255, 0.08);
+  --glass-border: rgba(255, 255, 255, 0.18);
+  --glass-blur: 12px;
+  --glass-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+}
+
 .glass {
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.18);
-  backdrop-filter: blur(12px);
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  background: var(--glass-bg);
+  border: 1px solid var(--glass-border);
+  backdrop-filter: blur(var(--glass-blur));
+  box-shadow: var(--glass-shadow);
 }
 
 .dark .glass {
-  background: rgba(255, 255, 255, 0.05);
-  border: 1px solid rgba(255, 255, 255, 0.1);
+  --glass-bg: rgba(255, 255, 255, 0.05);
+  --glass-border: rgba(255, 255, 255, 0.1);
 }
 
 .hero-gradient {


### PR DESCRIPTION
## Summary
- adopt CSS variables for glass surfaces
- animate widgets, modals and drawer with framer-motion
- add lucide icons and glass cards to wishlist page

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e4f12248c8322b78aad9cdf105c13