### PR TITLE
Add KPI strip to Desejos page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ const MilhasLivelo = lazy(() => import('./pages/MilhasLivelo'));
 const MilhasLatam  = lazy(() => import('./pages/MilhasLatam'));
 const MilhasAzul   = lazy(() => import('./pages/MilhasAzul'));
 
-const ListaDesejos = lazy(() => import('./pages/ListaDesejos'));
+const Desejos = lazy(() => import('./pages/Desejos'));
 const ListaCompras = lazy(() => import('./pages/ListaCompras'));
 
 const Configuracoes = lazy(() => import('./pages/Configuracoes'));
@@ -116,7 +116,7 @@ function AppRoutes() {
             <Route path="/milhas/azul"      element={<MilhasAzul />} />
 
             {/* Listas */}
-            <Route path="/desejos" element={<ListaDesejos />} />
+            <Route path="/desejos" element={<Desejos />} />
             <Route path="/compras" element={<ListaCompras />} />
             <Route path="/lista-desejos" element={<Navigate to="/desejos" replace />} />
             <Route path="/lista-compras" element={<Navigate to="/compras" replace />} />

--- a/src/components/wishlist/WishlistFilters.tsx
+++ b/src/components/wishlist/WishlistFilters.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+
+import {
+  Select,
+  SelectTrigger,
+  SelectValue,
+  SelectContent,
+  SelectItem,
+} from "@/components/ui/select";
+
+export type WishlistFiltersProps = {
+  onPeriodChange?: (value: string) => void;
+  onStatusChange?: (value: string) => void;
+  onCategoryChange?: (value: string) => void;
+};
+
+export default function WishlistFilters({
+  onPeriodChange = () => {},
+  onStatusChange = () => {},
+  onCategoryChange = () => {},
+}: WishlistFiltersProps) {
+  return (
+    <div className="flex flex-wrap gap-2">
+      <Select defaultValue="all" onValueChange={onPeriodChange}>
+        <SelectTrigger className="w-[160px]">
+          <SelectValue placeholder="Período" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">Todo período</SelectItem>
+          <SelectItem value="30d">Últimos 30 dias</SelectItem>
+          <SelectItem value="6m">Últimos 6 meses</SelectItem>
+          <SelectItem value="1y">Último ano</SelectItem>
+        </SelectContent>
+      </Select>
+
+      <Select defaultValue="all" onValueChange={onStatusChange}>
+        <SelectTrigger className="w-[160px]">
+          <SelectValue placeholder="Status" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">Todos</SelectItem>
+          <SelectItem value="active">Ativo</SelectItem>
+          <SelectItem value="completed">Concluído</SelectItem>
+        </SelectContent>
+      </Select>
+
+      <Select defaultValue="all" onValueChange={onCategoryChange}>
+        <SelectTrigger className="w-[160px]">
+          <SelectValue placeholder="Categoria" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="all">Todas</SelectItem>
+          <SelectItem value="electronics">Eletrônicos</SelectItem>
+          <SelectItem value="other">Outras</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+

--- a/src/pages/Desejos.tsx
+++ b/src/pages/Desejos.tsx
@@ -7,6 +7,7 @@ import KPIStrip, { type KpiItem } from "@/components/dashboard/KPIStrip";
 import WishlistNewItemModal, { WishlistItem } from "@/components/wishlist/WishlistNewItemModal";
 import WishlistSimulateModal from "@/components/wishlist/WishlistSimulateModal";
 import WishlistDrawer from "@/components/wishlist/WishlistDrawer";
+import WishlistFilters from "@/components/wishlist/WishlistFilters";
 
 export default function Desejos() {
   const [items, setItems] = React.useState<WishlistItem[]>([
@@ -85,6 +86,11 @@ export default function Desejos() {
 
   return (
     <div className="space-y-4">
+      <WishlistFilters
+        onPeriodChange={() => {}}
+        onStatusChange={() => {}}
+        onCategoryChange={() => {}}
+      />
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">🛍️ Desejos</h1>
         <Button onClick={() => setNewOpen(true)}>Novo desejo</Button>

--- a/src/pages/Desejos.tsx
+++ b/src/pages/Desejos.tsx
@@ -1,7 +1,9 @@
 import * as React from "react";
+import { ShoppingBag, Tag, Flag, PiggyBank } from "lucide-react";
 
 import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import KPIStrip, { type KpiItem } from "@/components/dashboard/KPIStrip";
 import WishlistNewItemModal, { WishlistItem } from "@/components/wishlist/WishlistNewItemModal";
 import WishlistSimulateModal from "@/components/wishlist/WishlistSimulateModal";
 import WishlistDrawer from "@/components/wishlist/WishlistDrawer";
@@ -42,12 +44,52 @@ export default function Desejos() {
     setItems(prev => [...prev, item]);
   };
 
+  const kpiItems: KpiItem[] = [
+    {
+      title: "Itens",
+      icon: <ShoppingBag className="size-5" />,
+      value: items.length,
+      colorFrom: "#6366f1",
+      colorTo: "#8b5cf6",
+      spark: [2, 3, 4, 5, 4, 6],
+      sparkColor: "#6366f1",
+    },
+    {
+      title: "Em promoção",
+      icon: <Tag className="size-5" />,
+      value: items.filter(i => i.precoAtual < i.precoAlvo).length,
+      colorFrom: "#f59e0b",
+      colorTo: "#f97316",
+      spark: [1, 2, 1, 3, 2, 3],
+      sparkColor: "#f59e0b",
+    },
+    {
+      title: "Prioridade alta",
+      icon: <Flag className="size-5" />,
+      value: items.filter(i => i.prioridade === "Alta").length,
+      colorFrom: "#ef4444",
+      colorTo: "#f97316",
+      spark: [3, 3, 4, 5, 4, 5],
+      sparkColor: "#ef4444",
+    },
+    {
+      title: "Economia potencial",
+      icon: <PiggyBank className="size-5" />,
+      value: items.reduce((s, i) => s + Math.max(0, i.precoAlvo - i.precoAtual), 0),
+      colorFrom: "#10b981",
+      colorTo: "#34d399",
+      spark: [4, 5, 6, 5, 7, 6],
+      sparkColor: "#10b981",
+    },
+  ];
+
   return (
     <div className="space-y-4">
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">🛍️ Desejos</h1>
         <Button onClick={() => setNewOpen(true)}>Novo desejo</Button>
       </div>
+      <KPIStrip items={kpiItems} />
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {items.map(item => (
           <Card


### PR DESCRIPTION
## Summary
- add KPI strip with wishlist metrics
- rename ListaDesejos page to Desejos and update routes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e510e947c83229730c607e3f4601e