### PR TITLE
feat: add wishlist move to shopping list

### DIFF
--- a/src/pages/ListaDesejos.tsx
+++ b/src/pages/ListaDesejos.tsx
@@ -1,0 +1,86 @@
+import { useEffect, useState } from "react";
+
+import { supabase } from "@/lib/supabaseClient";
+import { Button } from "@/components/ui/button";
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+type WishlistItem = {
+  id: string;
+  title: string;
+  status: string;
+};
+
+export default function ListaDesejos() {
+  const [items, setItems] = useState<WishlistItem[]>([]);
+  const [open, setOpen] = useState(false);
+  const [current, setCurrent] = useState<WishlistItem | null>(null);
+  const [quantity, setQuantity] = useState(1);
+  const [estimatedPrice, setEstimatedPrice] = useState("");
+  const [store, setStore] = useState("");
+  const [dueAt, setDueAt] = useState("");
+
+  useEffect(() => {
+    const load = async () => {
+      const { data } = await supabase.from("wishlist_items").select("*");
+      setItems(data as WishlistItem[] ?? []);
+    };
+    load();
+  }, []);
+
+  const handleMove = async () => {
+    if (!current) return;
+    await supabase.rpc("wishlist_move_to_shopping_list", {
+      item_id: current.id,
+      quantity,
+      estimated_price: estimatedPrice ? Number(estimatedPrice) : null,
+      store,
+      due_at: dueAt || null,
+    });
+    setItems(prev => prev.map(i => i.id === current.id ? { ...i, status: "ready" } : i));
+    setOpen(false);
+  };
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-2xl font-bold">🛍️ Lista de desejos</h1>
+      <ul className="space-y-2">
+        {items.map(item => (
+          <li key={item.id} className="flex items-center justify-between">
+            <span>{item.title} - {item.status}</span>
+            <Button onClick={() => { setCurrent(item); setOpen(true); }}>Mover p/ Compras</Button>
+          </li>
+        ))}
+      </ul>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Mover para compras</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div>
+              <Label htmlFor="quantity">Quantidade</Label>
+              <Input id="quantity" type="number" value={quantity} onChange={e => setQuantity(Number(e.target.value))} />
+            </div>
+            <div>
+              <Label htmlFor="price">Preço estimado</Label>
+              <Input id="price" type="number" value={estimatedPrice} onChange={e => setEstimatedPrice(e.target.value)} />
+            </div>
+            <div>
+              <Label htmlFor="store">Loja</Label>
+              <Input id="store" value={store} onChange={e => setStore(e.target.value)} />
+            </div>
+            <div>
+              <Label htmlFor="due">Data prevista</Label>
+              <Input id="due" type="date" value={dueAt} onChange={e => setDueAt(e.target.value)} />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button onClick={handleMove}>Confirmar</Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/supabase/migrations/20250813000000_wishlist_move_to_shopping_list.sql
+++ b/supabase/migrations/20250813000000_wishlist_move_to_shopping_list.sql
@@ -1,0 +1,28 @@
+create extension if not exists "pgcrypto";
+
+create table if not exists wishlist_items (
+  id uuid primary key default gen_random_uuid(),
+  title text not null,
+  status text not null default 'new',
+  created_at timestamptz default now()
+);
+
+create or replace function wishlist_move_to_shopping_list(
+  item_id uuid,
+  quantity numeric,
+  estimated_price numeric,
+  store text,
+  due_at date
+)
+returns void
+language plpgsql
+as $$
+begin
+  insert into shopping_list (item_id, quantity, estimated_price, store, due_at)
+  values (item_id, quantity, estimated_price, store, due_at);
+
+  update wishlist_items
+  set status = 'ready'
+  where id = item_id;
+end;
+$$;


### PR DESCRIPTION
## Summary
- build ListaDesejos page that loads Supabase wishlist items
- allow moving wishlist items to shopping list via RPC and modal
- create migration for wishlist table and move RPC

## Testing
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e55c17f6883228a68f131c1a33373