### PR TITLE
feat(integrations): create transaction and pending miles on mark bought

### DIFF
--- a/src/components/ModalTransacao.tsx
+++ b/src/components/ModalTransacao.tsx
@@ -14,6 +14,7 @@ import { useCategories } from '@/hooks/useCategories';
 import { useAccounts } from '@/hooks/useAccounts';
 import { useCreditCards } from '@/hooks/useCreditCards';
 import MoneyInput from '@/components/MoneyInput';
+import type { ShoppingItem } from '@/hooks/useTransactions';
 
 // --- Types -----------------------------------------------------------------
 export type BaseData = {
@@ -46,6 +47,35 @@ export type Props = {
   initialData?: BaseData | null;
   onSubmit: (data: BaseData) => Promise<void> | void;
 };
+
+export function baseDataFromShoppingItem(item: ShoppingItem, pricePaid?: number): BaseData {
+  return {
+    date: new Date().toISOString().slice(0, 10),
+    description: item.title,
+    value: pricePaid ?? item.price ?? item.estimated_price ?? 0,
+    type: 'expense',
+    category: 'Outros',
+    category_id: item.wishlist_category_id ?? item.category_id ?? null,
+    payment_method: 'Outro',
+    source_kind: 'account',
+    source_id: null,
+    source_label: null,
+    installments: null,
+    notes: null,
+    attachment_file: null,
+    miles:
+      item.accumulates_miles &&
+      item.miles_program &&
+      item.miles_qty &&
+      item.miles_expected_at
+        ? {
+            program: item.miles_program as any,
+            amount: item.miles_qty,
+            expected_at: item.miles_expected_at,
+          }
+        : null,
+  };
+}
 
 const METODOS = ['Pix','Cartão','Dinheiro','Boleto','Transferência','Outro'];
 

--- a/src/hooks/useMiles.ts
+++ b/src/hooks/useMiles.ts
@@ -1,0 +1,25 @@
+import { useCallback } from 'react';
+
+import { supabase } from '@/lib/supabaseClient';
+
+export type PendingMilesInput = {
+  transaction_id: number;
+  program: string;
+  qty: number;
+  expected_at: string;
+};
+
+export function useMiles() {
+  const recordPending = useCallback(async ({ transaction_id, program, qty, expected_at }: PendingMilesInput) => {
+    const { data, error } = await supabase
+      .from('miles')
+      .insert({ transaction_id, program, qty, expected_at, status: 'pending' })
+      .select()
+      .single();
+    if (error) throw error;
+    return data;
+  }, []);
+
+  return { recordPending } as const;
+}
+

--- a/src/hooks/useTransactions.ts
+++ b/src/hooks/useTransactions.ts
@@ -1,5 +1,7 @@
 import { useEffect, useMemo, useState, useCallback } from "react";
 
+import { useMiles } from "./useMiles";
+
 import { supabase } from "@/lib/supabaseClient";
 import { exportTransactionsPDF } from "@/utils/pdf";
 
@@ -32,6 +34,19 @@ export type TransactionInput = {
   // Extra (futuro)
   notes?: string | null;
   attachment_url?: string | null;
+};
+
+export type ShoppingItem = {
+  id: string;
+  title: string;
+  estimated_price?: number | null;
+  price?: number | null;
+  category_id?: string | null;
+  wishlist_category_id?: string | null;
+  accumulates_miles?: boolean;
+  miles_program?: string | null;
+  miles_qty?: number | null;
+  miles_expected_at?: string | null;
 };
 
 // ===== Helpers de data (seguro em UTC) =====================================
@@ -153,6 +168,7 @@ export function useTransactions(year?: any, month?: any) {
   const [data, setData] = useState<Transaction[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const { recordPending } = useMiles();
 
   const { y, m, start, end } = useMemo(() => monthBoundsISO(year, month), [year, month]);
 
@@ -275,6 +291,44 @@ export function useTransactions(year?: any, month?: any) {
     return inserted;
   }, [create, bulkCreate]);
 
+  const createFromShoppingItem = useCallback(
+    async (item: ShoppingItem, pricePaid?: number) => {
+      const value = Math.abs(pricePaid ?? item.price ?? item.estimated_price ?? 0);
+      if (!value) throw new Error('Preço inválido');
+      const row: Omit<Transaction, 'id'> = {
+        date: new Date().toISOString().slice(0, 10),
+        description: item.title,
+        amount: -value,
+        category_id: item.wishlist_category_id ?? item.category_id ?? null,
+        account_id: null,
+        card_id: null,
+        installment_no: null,
+        installment_total: null,
+        parent_installment_id: null,
+      };
+      const t = await create(row);
+      if (
+        item.accumulates_miles &&
+        item.miles_program &&
+        item.miles_qty &&
+        item.miles_expected_at
+      ) {
+        try {
+          await recordPending({
+            transaction_id: t.id,
+            program: item.miles_program,
+            qty: item.miles_qty,
+            expected_at: item.miles_expected_at,
+          });
+        } catch (e) {
+          console.warn(e);
+        }
+      }
+      return t;
+    },
+    [create, recordPending]
+  );
+
   // ----- Filtros locais (UI) -----------------------------------------------
 
   /** Obtém uma transação pelo id a partir do cache atual (ou undefined). */
@@ -395,6 +449,7 @@ export function useTransactions(year?: any, month?: any) {
     exportTransactionsPDF,
     // alto nível
     addSmart,
+    createFromShoppingItem,
     filterLocal,
     kpis,
   } as const;


### PR DESCRIPTION
## Summary
- allow building transaction form data from shopping items
- create pending miles records via new useMiles hook
- add helper to create transaction (and miles) when shopping item is marked bought

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e5775ea2083228a1d9ec72d5eeaae