### PR TITLE
feat: add KPI strip component

### DIFF
--- a/src/components/home/KPIStrip.tsx
+++ b/src/components/home/KPIStrip.tsx
@@ -1,0 +1,40 @@
+import { motion } from 'framer-motion';
+import type { LucideIcon } from 'lucide-react';
+
+import { AnimatedNumber } from '@/components/ui/AnimatedNumber';
+import { cn } from '@/lib/utils';
+
+export interface KpiMetric {
+  title: string;
+  icon: LucideIcon;
+  value: number;
+  color: string;
+}
+
+export function KpiCard({ title, icon: Icon, value, color }: KpiMetric) {
+  return (
+    <motion.div
+      className="flex flex-col gap-1 rounded-xl bg-card p-4 text-card-foreground"
+      initial={{ opacity: 0, y: 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.3 }}
+    >
+      <Icon className={cn('h-5 w-5', color)} />
+      <AnimatedNumber value={value} currency={false} className={cn('text-3xl', color)} />
+      <span className="text-sm text-muted-foreground">{title}</span>
+    </motion.div>
+  );
+}
+
+export function KPIStrip({ metrics }: { metrics: KpiMetric[] }) {
+  return (
+    <div
+      className="grid gap-4"
+      style={{ gridTemplateColumns: `repeat(auto-fit, minmax(120px, 1fr))` }}
+    >
+      {metrics.map((m) => (
+        <KpiCard key={m.title} {...m} />
+      ))}
+    </div>
+  );
+}

--- a/src/components/ui/AnimatedNumber.tsx
+++ b/src/components/ui/AnimatedNumber.tsx
@@ -1,7 +1,9 @@
 import { useEffect } from 'react';
 import { motion, useSpring, useTransform } from 'framer-motion';
 
-export function AnimatedNumber({ value, currency=true }:{ value:number; currency?:boolean }) {
+import { cn } from '@/lib/utils';
+
+export function AnimatedNumber({ value, currency=true, className='' }:{ value:number; currency?:boolean; className?:string }) {
   const spring = useSpring(0, { stiffness: 120, damping: 20 });
   useEffect(() => {
     spring.set(value);
@@ -14,7 +16,7 @@ export function AnimatedNumber({ value, currency=true }:{ value:number; currency
   );
 
   return (
-    <motion.span className="font-numeric font-semibold text-2xl">
+    <motion.span className={cn('font-numeric font-semibold text-2xl', className)}>
       {text}
     </motion.span>
   );


### PR DESCRIPTION
## Summary
- add reusable KPI strip with animated metric cards
- allow AnimatedNumber to accept custom classes

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e5e0c7e6c83228a1d0c7cb3768c98