### PR TITLE
feat(home): add forecast chart and alert list

### DIFF
--- a/src/components/home/AlertList.tsx
+++ b/src/components/home/AlertList.tsx
@@ -1,0 +1,79 @@
+// src/components/home/AlertList.tsx
+import { useState } from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+
+export type Alert = {
+  id: string | number;
+  title: string;
+  description?: string;
+};
+
+export type AlertListProps = {
+  alerts: Alert[];
+  onResolve?: (id: Alert['id']) => void;
+};
+
+export default function AlertList({ alerts, onResolve }: AlertListProps) {
+  const [selected, setSelected] = useState<Alert | null>(null);
+
+  return (
+    <div>
+      {alerts.length === 0 ? (
+        <p className="text-sm text-muted-foreground">Nenhum alerta.</p>
+      ) : (
+        <ul className="space-y-2">
+          {alerts.map((a) => (
+            <li key={a.id} className="flex items-center justify-between rounded-md border p-2 text-sm">
+              <button
+                type="button"
+                onClick={() => setSelected(a)}
+                className="flex-1 text-left"
+              >
+                <div className="font-medium">{a.title}</div>
+                {a.description && <p className="text-muted-foreground">{a.description}</p>}
+              </button>
+              {onResolve && (
+                <button
+                  type="button"
+                  onClick={() => onResolve(a.id)}
+                  className="ml-2 text-emerald-700 hover:underline"
+                >
+                  Resolvido
+                </button>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <Dialog.Root open={!!selected} onOpenChange={(o) => !o && setSelected(null)}>
+        <Dialog.Portal>
+          <Dialog.Overlay className="fixed inset-0 bg-black/50" />
+          <Dialog.Content className="fixed right-0 top-0 z-50 flex h-full w-80 flex-col bg-background p-4 shadow-xl focus:outline-none">
+            {selected && (
+              <div className="flex flex-col h-full">
+                <Dialog.Title className="text-lg font-semibold">{selected.title}</Dialog.Title>
+                <div className="mt-4 flex-1 overflow-auto">
+                  {selected.description && <p className="text-sm whitespace-pre-wrap">{selected.description}</p>}
+                </div>
+                {onResolve && (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onResolve(selected.id);
+                      setSelected(null);
+                    }}
+                    className="mt-4 self-end text-sm text-emerald-700 hover:underline"
+                  >
+                    Marcar como resolvido
+                  </button>
+                )}
+              </div>
+            )}
+          </Dialog.Content>
+        </Dialog.Portal>
+      </Dialog.Root>
+    </div>
+  );
+}
+

--- a/src/components/home/ForecastChart.tsx
+++ b/src/components/home/ForecastChart.tsx
@@ -1,0 +1,58 @@
+// src/components/home/ForecastChart.tsx
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  Tooltip,
+} from 'recharts';
+
+import type { Transaction } from '@/hooks/useTransactions';
+import { useForecast, forecastCashflowNext30 } from '@/hooks/useForecast';
+import { formatCurrency } from '@/lib/utils';
+import { SkeletonLine } from '@/components/ui/SkeletonLine';
+
+export type ForecastChartProps = {
+  transactions?: Transaction[];
+  window?: number;
+  isLoading?: boolean;
+};
+
+export default function ForecastChart({
+  transactions = [],
+  window = 7,
+  isLoading = false,
+}: ForecastChartProps) {
+  const { data } = useForecast(transactions, window);
+  const chartData = data?.length ? data : forecastCashflowNext30([], window);
+  const hasData = chartData.length > 0;
+
+  return (
+    <div className="rounded-xl border bg-white dark:bg-slate-900 p-4">
+      <h3 className="font-medium mb-3">Previsão de fluxo de caixa</h3>
+      <div className="h-[320px]">
+        {isLoading ? (
+          <SkeletonLine className="h-full w-full" />
+        ) : hasData ? (
+          <ResponsiveContainer>
+            <LineChart data={chartData} margin={{ top: 12, right: 16, bottom: 12, left: 8 }}>
+              <XAxis dataKey="day" />
+              <YAxis tickFormatter={(v) => formatCurrency(Number(v))} />
+              <Tooltip
+                formatter={(v: unknown) => formatCurrency(Number(v))}
+                labelFormatter={(l: unknown) => `Dia ${l}`}
+              />
+              <Line type="monotone" dataKey="value" stroke="#10b981" strokeWidth={2} dot={{ r: 2 }} />
+            </LineChart>
+          </ResponsiveContainer>
+        ) : (
+          <div className="h-full flex items-center justify-center text-sm text-slate-500">
+            Sem dados
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add 30-day cash flow forecast chart using moving average
- add alert list with resolve and detail drawer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e5e1274dc8322ab6f42236708f10c