### PR TITLE
feat: add insights section

### DIFF
--- a/src/components/home/InsightCard.tsx
+++ b/src/components/home/InsightCard.tsx
@@ -1,0 +1,44 @@
+import type { ReactNode } from "react";
+import { AlertCircle, Plane, Receipt, Target, TrendingUp, Utensils, Wallet } from "lucide-react";
+
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
+import type { Insight } from "@/hooks/useInsights";
+
+function iconFor(id: string): ReactNode {
+  if (id.startsWith("food")) return <Utensils className="h-5 w-5" />;
+  if (id.startsWith("cat")) return <TrendingUp className="h-5 w-5" />;
+  if (id.startsWith("budget")) return <Wallet className="h-5 w-5" />;
+  if (id.startsWith("mile")) return <Plane className="h-5 w-5" />;
+  if (id.startsWith("bill")) return <Receipt className="h-5 w-5" />;
+  if (id.startsWith("goal")) return <Target className="h-5 w-5" />;
+  return <AlertCircle className="h-5 w-5" />;
+}
+
+export default function InsightCard({ insight }: { insight: Insight }) {
+  const icon = iconFor(insight.id);
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="group card-surface flex w-full items-start gap-3 p-4 text-left transition-transform hover:-translate-y-0.5 hover:shadow-lg"
+        >
+          <span className="mt-1 text-emerald-600 dark:text-emerald-400">{icon}</span>
+          <span className="text-sm text-foreground/90 group-hover:text-foreground">
+            {insight.message}
+          </span>
+        </button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            {icon}
+            Insight
+          </DialogTitle>
+          <DialogDescription>{insight.message}</DialogDescription>
+        </DialogHeader>
+      </DialogContent>
+    </Dialog>
+  );
+}
+

--- a/src/components/home/InsightsSection.tsx
+++ b/src/components/home/InsightsSection.tsx
@@ -1,0 +1,32 @@
+import InsightCard from "./InsightCard";
+
+import { useInsights } from "@/hooks/useInsights";
+import { useTransactions } from "@/hooks/useTransactions";
+import { useCategories } from "@/hooks/useCategories";
+import { useBills } from "@/hooks/useBills";
+import { useGoals } from "@/hooks/useGoals";
+import { usePeriod } from "@/state/periodFilter";
+
+export default function InsightsSection() {
+  const { year, month } = usePeriod();
+  const { data: transactions } = useTransactions(year, month);
+  const { flat: categories } = useCategories();
+  const { data: bills } = useBills(year, month);
+  const { data: goals } = useGoals();
+
+  const insights = useInsights(
+    { year, month },
+    { transactions, categories, bills, goals, miles: [] }
+  );
+
+  if (!insights.length) return null;
+
+  return (
+    <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      {insights.map((ins) => (
+        <InsightCard key={ins.id} insight={ins} />
+      ))}
+    </section>
+  );
+}
+

--- a/src/components/home/index.ts
+++ b/src/components/home/index.ts
@@ -1,0 +1,2 @@
+export { default as InsightsSection } from './InsightsSection';
+export { default as InsightCard } from './InsightCard';


### PR DESCRIPTION
## Summary
- add home insights section consuming useInsights
- create InsightCard with modal details and glassmorphism styling
- export home insights components

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e5e0f71108322a1a771c8795d6c86