### PR TITLE
style: apply glass utility and unify rounding

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -161,7 +161,7 @@ export function Sidebar() {
         ].join(" ")}
       >
         <div className="flex h-full flex-col">
-          <div className="m-3 flex items-center rounded-2xl sidebar-header p-5 ring-1 ring-white/10">
+          <div className="m-3 flex items-center rounded-xl sidebar-header p-5 ring-1 ring-white/10">
             <Logo size="lg" />
             {!collapsed && <span className="ml-2 text-xl font-semibold">FY</span>}
             <div className="ml-auto flex items-center gap-2">
@@ -267,7 +267,7 @@ export function Sidebar() {
           <div className="p-2">
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <button className="flex w-full items-center gap-3 rounded-2xl p-2 text-left hover:bg-emerald-600/10 transition">
+                  <button className="flex w-full items-center gap-3 rounded-xl p-2 text-left hover:bg-emerald-600/10 transition">
                   <div className="flex h-9 w-9 items-center justify-center rounded-full bg-emerald-500 text-sm font-semibold text-white">
                     {initials}
                   </div>

--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -526,7 +526,7 @@ export default function TransactionsTable({
 
       {/* Dialog Duplicar p/ mês (se habilitado) */}
       <Dialog open={dupOpen} onOpenChange={setDupOpen}>
-        <DialogContent className="sm:max-w-md bg-white/80 dark:bg-zinc-950/80 backdrop-blur rounded-2xl border border-white/30 dark:border-white/10 shadow-xl">
+          <DialogContent className="sm:max-w-md bg-white/80 dark:bg-zinc-950/80 backdrop-blur rounded-xl border border-white/30 dark:border-white/10 shadow-xl">
           <DialogHeader>
             <DialogTitle className="text-base sm:text-lg">Duplicar selecionadas</DialogTitle>
           </DialogHeader>

--- a/src/components/dashboard/HeroSection.tsx
+++ b/src/components/dashboard/HeroSection.tsx
@@ -1,34 +1,37 @@
 import { Link } from "react-router-dom";
+import { ArrowRight } from "lucide-react";
 
 // Hero section displayed at the top of the dashboard.
 // This component contains only presentational markup and
 // can be replaced by a more feature rich version later on.
-export default function HeroSection() {
-  return (
-    <div className="relative overflow-hidden rounded-2xl bg-gradient-to-r from-emerald-600 to-teal-600 p-6 text-white backdrop-blur-sm border-b border-white/10 shadow-lg">
+  export default function HeroSection() {
+    return (
+      <div className="glass hero-gradient relative overflow-hidden rounded-xl p-6 text-white">
       <div className="relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div className="flex items-center gap-3">
           <LogoFY size={44} />
           <h1 className="text-2xl md:text-3xl font-bold tracking-tight">Finanças do Yago</h1>
         </div>
-        <div className="mt-1 flex gap-2 md:mt-0">
-          <Link
-            to="/financas/mensal"
-            className="rounded-xl bg-white/90 px-4 py-2 font-medium text-emerald-700 shadow transition hover:bg-white"
-          >
-            Ver Finanças
-          </Link>
-          <Link
-            to="/investimentos/resumo"
-            className="rounded-xl bg-white/15 px-4 py-2 font-medium text-white ring-1 ring-white/30 transition hover:bg-white/20"
-          >
-            Ver Investimentos
-          </Link>
+          <div className="mt-1 flex gap-2 md:mt-0">
+            <Link
+              to="/financas/mensal"
+              className="rounded-xl bg-white/90 px-4 py-2 font-medium text-emerald-700 shadow transition hover:bg-white"
+            >
+              Ver Finanças
+              <ArrowRight className="ml-2 inline size-4" />
+            </Link>
+            <Link
+              to="/investimentos/resumo"
+              className="rounded-xl bg-white/15 px-4 py-2 font-medium text-white ring-1 ring-white/30 transition hover:bg-white/20"
+            >
+              Ver Investimentos
+              <ArrowRight className="ml-2 inline size-4" />
+            </Link>
+          </div>
         </div>
       </div>
-    </div>
-  );
-}
+    );
+  }
 
 // Logo “FY” estilizada em SVG
 function LogoFY({ size = 44 }: { size?: number }) {

--- a/src/components/dashboard/HeroSection.tsx
+++ b/src/components/dashboard/HeroSection.tsx
@@ -4,34 +4,36 @@ import { ArrowRight } from "lucide-react";
 // Hero section displayed at the top of the dashboard.
 // This component contains only presentational markup and
 // can be replaced by a more feature rich version later on.
-  export default function HeroSection() {
-    return (
-      <div className="glass hero-gradient relative overflow-hidden rounded-xl p-6 text-white">
+export default function HeroSection() {
+  return (
+    <div className="glass hero-gradient relative overflow-hidden rounded-xl p-6 text-white">
       <div className="relative flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div className="flex items-center gap-3">
           <LogoFY size={44} />
-          <h1 className="text-2xl md:text-3xl font-bold tracking-tight">Finanças do Yago</h1>
+          <h1 className="text-2xl md:text-3xl font-bold tracking-tight">
+            Finanças do Yago
+          </h1>
         </div>
-          <div className="mt-1 flex gap-2 md:mt-0">
-            <Link
-              to="/financas/mensal"
-              className="rounded-xl bg-white/90 px-4 py-2 font-medium text-emerald-700 shadow transition hover:bg-white"
-            >
-              Ver Finanças
-              <ArrowRight className="ml-2 inline size-4" />
-            </Link>
-            <Link
-              to="/investimentos/resumo"
-              className="rounded-xl bg-white/15 px-4 py-2 font-medium text-white ring-1 ring-white/30 transition hover:bg-white/20"
-            >
-              Ver Investimentos
-              <ArrowRight className="ml-2 inline size-4" />
-            </Link>
-          </div>
+        <div className="mt-1 flex gap-2 md:mt-0">
+          <Link
+            to="/financas/mensal"
+            className="rounded-xl bg-white/90 px-4 py-2 font-medium text-emerald-700 shadow transition hover:bg-white"
+          >
+            Ver Finanças
+            <ArrowRight className="ml-2 inline size-4" />
+          </Link>
+          <Link
+            to="/investimentos/resumo"
+            className="rounded-xl bg-white/15 px-4 py-2 font-medium text-white ring-1 ring-white/30 transition hover:bg-white/20"
+          >
+            Ver Investimentos
+            <ArrowRight className="ml-2 inline size-4" />
+          </Link>
         </div>
       </div>
-    );
-  }
+    </div>
+  );
+}
 
 // Logo “FY” estilizada em SVG
 function LogoFY({ size = 44 }: { size?: number }) {

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-2xl border border-white/40 bg-white/70 text-card-foreground shadow-sm backdrop-blur dark:border-white/10 dark:bg-white/5",
+        "rounded-xl border border-white/40 bg-white/70 text-card-foreground shadow-sm backdrop-blur dark:border-white/10 dark:bg-white/5",
       className
     )}
     {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -40,10 +40,10 @@ const DialogContent = React.forwardRef<
     <DialogOverlay />
     <MotionContent
       ref={ref}
-      className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-2xl border border-white/40 bg-white/70 p-6 shadow-2xl backdrop-blur dark:border-white/10 dark:bg-white/5",
-        className
-      )}
+        className={cn(
+          "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 rounded-xl border border-white/40 bg-white/70 p-6 shadow-2xl backdrop-blur dark:border-white/10 dark:bg-white/5",
+          className
+        )}
       initial={{ opacity: 0, scale: 0.95 }}
       animate={{ opacity: 1, scale: 1 }}
       exit={{ opacity: 0, scale: 0.95 }}

--- a/src/index.css
+++ b/src/index.css
@@ -211,17 +211,17 @@ body::after {
     @apply bg-gradient-to-tr from-emerald-600 to-emerald-400 text-white;
   }
   .glass {
-    @apply bg-white/70 backdrop-blur-md border border-white/40 shadow-sm;
+    @apply rounded-xl bg-white/70 backdrop-blur-md border border-white/40 shadow-sm;
   }
   .dark .glass {
     @apply bg-white/5 border-white/10;
   }
   /* Cards e KPIs padronizados */
   .card-surface {
-    @apply rounded-2xl bg-white/70 backdrop-blur-xl border border-white/40 shadow-sm;
+    @apply glass bg-gradient-to-br from-white/60 to-white/40;
   }
   .dark .card-surface {
-    @apply bg-white/5 border-white/10;
+    @apply bg-gradient-to-br from-white/10 to-white/5;
   }
   .kpi {
     @apply card-surface p-5 sm:p-6 flex items-start gap-4;

--- a/src/pages/Confirm.tsx
+++ b/src/pages/Confirm.tsx
@@ -35,7 +35,7 @@ export default function Confirm() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-emerald-100 flex items-center justify-center p-4">
-      <div className="w-full max-w-md rounded-2xl bg-white/70 backdrop-blur shadow-xl border border-emerald-100 p-6">
+        <div className="w-full max-w-md glass border border-emerald-100/50 p-6">
         <div className="flex items-center gap-3 mb-2">
           <div className="h-10 w-10 rounded-full bg-emerald-600 text-white grid place-items-center font-bold">FY</div>
           <h1 className="text-xl font-semibold text-emerald-900">Confirmando seu e-mail…</h1>

--- a/src/pages/FinancasMensal.tsx
+++ b/src/pages/FinancasMensal.tsx
@@ -575,8 +575,8 @@ export default function FinancasMensal() {
       />
 
       {/* Dialog Duplicar p/ mês */}
-      <Dialog open={dupOpen} onOpenChange={setDupOpen}>
-        <DialogContent className="sm:max-w-md bg-white/80 dark:bg-zinc-950/80 backdrop-blur rounded-2xl border border-white/30 dark:border-white/10 shadow-xl">
+        <Dialog open={dupOpen} onOpenChange={setDupOpen}>
+          <DialogContent className="sm:max-w-md bg-white/80 dark:bg-zinc-950/80 backdrop-blur rounded-xl border border-white/30 dark:border-white/10 shadow-xl">
           <DialogHeader>
             <DialogTitle className="text-base sm:text-lg">Duplicar lançamentos</DialogTitle>
           </DialogHeader>

--- a/src/pages/HomeOverview.tsx
+++ b/src/pages/HomeOverview.tsx
@@ -250,8 +250,8 @@ export default function HomeOverview() {
         animate="show"
       >
           {/* HERO --------------------------------------------------- */}
-          <motion.div variants={item}>
-            <div className="hero-gradient relative overflow-hidden rounded-2xl border border-white/15 p-8 text-neutral-100 shadow-lg">
+            <motion.div variants={item}>
+              <div className="glass hero-gradient relative overflow-hidden rounded-xl p-8 text-neutral-100">
               <div className="grid gap-8 md:grid-cols-2 md:items-center">
                 <div className="flex flex-col items-center gap-4 text-center md:items-start md:text-left">
                   <Logo size="lg" />

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -61,8 +61,8 @@ export default function ResetPassword() {
 
   if (phase === "preparing") {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-emerald-100 grid place-items-center p-4">
-        <div className="w-full max-w-md rounded-2xl bg-white/70 backdrop-blur shadow-xl border border-emerald-100 p-6">
+        <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-emerald-100 grid place-items-center p-4">
+          <div className="w-full max-w-md glass border border-emerald-100/50 p-6">
           <div className="flex items-center gap-3 mb-2">
             <div className="h-10 w-10 rounded-full bg-emerald-600 text-white grid place-items-center font-bold">FY</div>
             <h1 className="text-xl font-semibold text-emerald-900">Definir nova senha</h1>
@@ -74,11 +74,11 @@ export default function ResetPassword() {
   }
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-emerald-100 grid place-items-center p-4">
-      <form
-        onSubmit={onSubmit}
-        className="w-full max-w-md rounded-2xl bg-white/70 backdrop-blur shadow-xl border border-emerald-100 p-6 space-y-4"
-      >
+      <div className="min-h-screen bg-gradient-to-br from-emerald-50 to-emerald-100 grid place-items-center p-4">
+        <form
+          onSubmit={onSubmit}
+          className="w-full max-w-md glass border border-emerald-100/50 p-6 space-y-4"
+        >
         <div className="flex items-center gap-3">
           <div className="h-10 w-10 rounded-full bg-emerald-600 text-white grid place-items-center font-bold">FY</div>
           <h1 className="text-xl font-semibold text-emerald-900">Definir nova senha</h1>

--- a/src/styles/glass.css
+++ b/src/styles/glass.css
@@ -3,6 +3,7 @@
   --glass-border: rgba(255, 255, 255, 0.18);
   --glass-blur: 12px;
   --glass-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  --glass-radius: 0.75rem;
 }
 
 .glass {
@@ -10,6 +11,7 @@
   border: 1px solid var(--glass-border);
   backdrop-filter: blur(var(--glass-blur));
   box-shadow: var(--glass-shadow);
+  border-radius: var(--glass-radius);
 }
 
 .dark .glass {

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,6 +1,6 @@
 @layer components {
   .menu-dropdown {
-    @apply bg-white/70 dark:bg-gray-900/70 backdrop-blur-xl border border-white/20 dark:border-white/10 shadow-xl rounded-2xl p-2;
+    @apply glass p-2;
   }
   .menu-item {
     @apply flex items-center gap-2 rounded-xl px-3 py-2 text-sm text-neutral-700 dark:text-neutral-200 transition-colors hover:bg-white/30 dark:hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/40;


### PR DESCRIPTION
## Summary
- add configurable radius to `glass` style and update card surfaces with gradients
- refactor hero and menus to use `glass`, lucide icons and consistent `rounded-xl`
- normalize dialogs, sidebar and pages to subtle glass cards with soft shadows

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e5e1804548322a37b93e911609f9d