### PR TITLE
feat: add finance summary page

### DIFF
--- a/src/hooks/usePeriod.ts
+++ b/src/hooks/usePeriod.ts
@@ -1,0 +1,1 @@
+export { usePeriod, PeriodProvider } from "@/state/periodFilter";

--- a/src/pages/FinancasResumo.tsx
+++ b/src/pages/FinancasResumo.tsx
@@ -1,333 +1,253 @@
 import { useMemo, useState } from "react";
-import { Plus, Download, Coins, TrendingUp, TrendingDown, PieChart, CalendarClock, Info } from "lucide-react";
-import { ResponsiveContainer, BarChart, Bar, XAxis, YAxis, Tooltip as RechartsTooltip, Legend } from "recharts";
+import {
+  Download,
+  Wallet,
+  ArrowUpCircle,
+  ArrowDownCircle,
+  Receipt,
+  ListTodo,
+  CalendarClock,
+} from "lucide-react";
 
 import PageHeader from "@/components/PageHeader";
-import PeriodSelector from "@/components/dashboard/PeriodSelector";
-import { WidgetCard, WidgetHeader, WidgetFooterAction } from "@/components/dashboard/WidgetCard";
+import SourcePicker, { type SourceValue } from "@/components/SourcePicker";
+import CategoryPicker from "@/components/CategoryPicker";
 import DailyBars from "@/components/charts/DailyBars";
 import CategoryDonut from "@/components/charts/CategoryDonut";
-import AlertList from "@/components/dashboard/AlertList";
-import RecurrenceList from "@/components/dashboard/RecurrenceList";
-import ForecastMiniChart from "@/components/financas/ForecastMiniChart";
-import { Button } from "@/components/ui/button";
+import TransactionsTable, { type UITransaction } from "@/components/TransactionsTable";
 import { EmptyState } from "@/components/ui/EmptyState";
 import { SkeletonLine } from "@/components/ui/SkeletonLine";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-import { Badge } from "@/components/ui/badge";
-import { ModalTransacao, type BaseData } from "@/components/ModalTransacao";
-import { usePeriod } from "@/state/periodFilter";
+import { Button } from "@/components/ui/button";
+import { usePeriod } from "@/hooks/usePeriod";
 import { useTransactions } from "@/hooks/useTransactions";
 import { useBills } from "@/hooks/useBills";
 import { useCategories } from "@/hooks/useCategories";
 import { useRecurrences } from "@/hooks/useRecurrences";
-import { useForecast } from "@/hooks/useForecast";
-import InsightBar from "@/components/financas/InsightBar";
-import { useInsights } from "@/hooks/useInsights";
 import { exportTransactionsPDF } from "@/utils/pdf";
 import { formatCurrency } from "@/lib/utils";
-import { getMonthlyAggregates, getLast12MonthsAggregates, getUpcomingBills, getBudgetUsage } from "@/lib/finance";
-import type { UITransaction } from "@/components/TransactionsTable";
-import { KpiCard } from "@/components/financas";
 
 export default function FinancasResumo() {
   const { month, year } = usePeriod();
-  const { data: transacoes, addSmart, list, loading: transLoading } = useTransactions(year, month);
-  const { data: contas } = useBills(year, month);
+  const { data: rawTransactions, loading: transLoading } = useTransactions(year, month);
+  const { data: bills, loading: billsLoading } = useBills(year, month);
   const { flat: categorias } = useCategories();
   const { data: recurrences } = useRecurrences();
-  const [modalOpen, setModalOpen] = useState(false);
-  const { data: forecastData } = useForecast();
 
-  const uiTransacoes: UITransaction[] = useMemo(() => {
-    return transacoes.map(t => ({
-      id: t.id,
-      date: t.date,
-      description: t.description,
-      value: Math.abs(t.amount),
-      type: t.amount >= 0 ? "income" : "expense",
-      category: t.category_id ? categorias.find(c => c.id === t.category_id)?.name ?? null : null,
-      category_id: t.category_id ?? null,
-      source_kind: t.card_id ? "card" : t.account_id ? "account" : null,
-      source_id: t.card_id ?? t.account_id ?? null,
-      account_id: t.account_id ?? null,
-      card_id: t.card_id ?? null,
-      installment_no: t.installment_no ?? null,
-      installment_total: t.installment_total ?? null,
-      origin: t.origin ?? null,
-    }));
-  }, [transacoes, categorias]);
+  const [source, setSource] = useState<SourceValue>({ kind: "account", id: "all" });
+  const [categoryId, setCategoryId] = useState<string | null>(null);
 
-  const monthlyAgg = useMemo(() => getMonthlyAggregates(transacoes), [transacoes]);
-  const upcomingBills = useMemo(() => getUpcomingBills(contas).map(b => ({ nome: b.description, vencimento: b.due_date, valor: b.amount })), [contas]);
-  const budgetUsage = useMemo(() => getBudgetUsage(categorias, transacoes), [categorias, transacoes]);
-  const last12 = useMemo(() => getLast12MonthsAggregates(transacoes).map(m => ({ mes: m.key.slice(5), entradas: m.income, saidas: m.expense })), [transacoes]);
-  const insights = useInsights(
-    { year, month },
-    { transactions: transacoes, categories: categorias, bills: contas, goals: [], miles: [] }
-  );
-
-  const wishlistImpact = useMemo(
+  const transactions: UITransaction[] = useMemo(
     () =>
-      transacoes
-        .filter(t => t.amount < 0 && t.origin?.wishlist_item_id)
-        .reduce((s, t) => s + Math.abs(t.amount), 0),
-    [transacoes]
-  );
-
-  const handlePDF = () => {
-    exportTransactionsPDF(
-      uiTransacoes.map(t => ({
+      rawTransactions.map((t) => ({
+        id: t.id,
         date: t.date,
         description: t.description,
-        category: t.category || "",
-        source_kind: t.source_kind,
-        value: t.value,
-        type: t.type,
+        value: Math.abs(t.amount),
+        type: t.amount >= 0 ? "income" : "expense",
+        category_id: t.category_id ?? null,
+        category: t.category_id
+          ? categorias.find((c) => c.id === t.category_id)?.name ?? null
+          : null,
+        account_id: t.account_id ?? null,
+        card_id: t.card_id ?? null,
+        source_kind: t.card_id ? "card" : t.account_id ? "account" : null,
+        source_id: t.card_id ?? t.account_id ?? null,
       })),
-      {},
-      `${year}-${String(month).padStart(2, "0")}`,
-    );
-  };
+    [rawTransactions, categorias]
+  );
 
-  const handleSubmit = async (data: BaseData) => {
-    await addSmart(data);
-    await list();
-    setModalOpen(false);
-  };
+  const filtered = useMemo(() => {
+    return transactions.filter((t) => {
+      const sourceOk =
+        source.id === "all"
+          ? true
+          : source.kind === "account"
+          ? t.account_id === source.id
+          : t.card_id === source.id;
+      const catOk = categoryId ? t.category_id === categoryId : true;
+      return sourceOk && catOk;
+    });
+  }, [transactions, source, categoryId]);
 
-  const kpiItems: KpiItem[] = [
-    {
-      title: "Saldo",
-      icon: <Coins className="size-5" />,
-      value: monthlyAgg.balance,
-    },
-    {
-      title: "Entradas",
-      icon: <TrendingUp className="size-5" />,
-      value: monthlyAgg.income,
-    },
-    {
-      title: "Saídas",
-      icon: <TrendingDown className="size-5" />,
-      value: monthlyAgg.expense,
-    },
-    {
-      title: "Orçamento",
-      icon: <PieChart className="size-5" />,
-      value: budgetUsage.reduce((s, b) => s + b.spent, 0),
-    },
-    {
-      title: "Contas a vencer",
-      icon: <CalendarClock className="size-5" />,
-      value: upcomingBills.reduce((s, b) => s + b.valor, 0),
-    },
+  const income = useMemo(
+    () => filtered.filter((t) => t.type === "income").reduce((s, t) => s + t.value, 0),
+    [filtered]
+  );
+  const expense = useMemo(
+    () => filtered.filter((t) => t.type === "expense").reduce((s, t) => s + t.value, 0),
+    [filtered]
+  );
+  const balance = income - expense;
+  const expenseCount = filtered.filter((t) => t.type === "expense").length;
+  const ticket = expenseCount ? expense / expenseCount : 0;
+  const totalTrans = filtered.length;
+
+  const today = new Date().toISOString().slice(0, 10);
+  const futureIncome = filtered
+    .filter((t) => t.type === "income" && t.date > today)
+    .reduce((s, t) => s + t.value, 0);
+  const recurrenceIncome = recurrences
+    .filter(
+      (r) =>
+        r.amount > 0 &&
+        r.nextDate.startsWith(`${year}-${String(month).padStart(2, "0")}`) &&
+        r.nextDate > today
+    )
+    .reduce((s, r) => s + r.amount, 0);
+  const toReceive = futureIncome + recurrenceIncome;
+
+  const categoriesData = useMemo(() => {
+    const byCat = filtered
+      .filter((t) => t.type === "expense")
+      .reduce<Record<string, number>>((acc, t) => {
+        const key = t.category || "Sem categoria";
+        acc[key] = (acc[key] ?? 0) + t.value;
+        return acc;
+      }, {});
+    const sorted = Object.entries(byCat).sort((a, b) => b[1] - a[1]);
+    const top = sorted.slice(0, 5);
+    const rest = sorted.slice(5).reduce((s, [, v]) => s + v, 0);
+    if (rest > 0) top.push(["Outras", rest]);
+    return top.map(([category, value]) => ({ category, value }));
+  }, [filtered]);
+
+  const monthStr = String(month).padStart(2, "0");
+  const recentTransactions = useMemo(
+    () => filtered.slice(-8).reverse(),
+    [filtered]
+  );
+
+  const upcomingBills = useMemo(() => {
+    const now = new Date();
+    const limit = new Date();
+    limit.setDate(now.getDate() + 14);
+    return bills.filter((b) => {
+      const d = new Date(b.due_date);
+      return !b.paid && d >= now && d <= limit;
+    });
+  }, [bills]);
+
+  const kpis = [
+    { title: "Saldo", icon: <Wallet className="size-5" />, value: balance, fmt: formatCurrency },
+    { title: "Entradas", icon: <ArrowUpCircle className="size-5" />, value: income, fmt: formatCurrency },
+    { title: "Saídas", icon: <ArrowDownCircle className="size-5" />, value: expense, fmt: formatCurrency },
+    { title: "Ticket médio", icon: <Receipt className="size-5" />, value: ticket, fmt: formatCurrency },
+    { title: "Transações do mês", icon: <ListTodo className="size-5" />, value: totalTrans, fmt: (n: number) => String(n) },
+    { title: "A receber", icon: <CalendarClock className="size-5" />, value: toReceive, fmt: formatCurrency },
   ];
 
-  return (
-    <div className="space-y-6 pb-24">
-      <PageHeader title="Finanças — Resumo" subtitle="Visão consolidada das suas finanças.">
-        <PeriodSelector />
-      </PageHeader>
+  const handleExport = () => {
+    const rows = filtered.map((t) => ({
+      date: t.date,
+      description: t.description,
+      category: t.category,
+      source_kind: t.source_kind,
+      value: t.value,
+      type: t.type,
+    }));
+    exportTransactionsPDF(rows, {}, `${year}-${monthStr}`);
+  };
 
-      <div className="flex gap-2">
-        <Button onClick={() => setModalOpen(true)}>
-          <Plus className="mr-2 h-4 w-4" /> Nova Transação
-        </Button>
-        <Button variant="outline" onClick={handlePDF}>
-          <Download className="mr-2 h-4 w-4" /> Exportar PDF
-        </Button>
+  return (
+    <div className="space-y-6">
+      <PageHeader
+        title="Finanças — Resumo"
+        breadcrumbs={[
+          { label: "Finanças", href: "/financas" },
+          { label: "Resumo" },
+        ]}
+        actions={
+          <Button onClick={handleExport} variant="secondary">
+            <Download className="mr-2 size-4" /> Exportar PDF
+          </Button>
+        }
+      />
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <SourcePicker
+          value={source}
+          onChange={setSource}
+          placeholder={undefined}
+          className="w-full sm:w-52"
+        />
+        <CategoryPicker
+          value={categoryId}
+          onChange={setCategoryId}
+          placeholder={undefined}
+          className="w-full sm:w-52"
+          allowClear
+        />
       </div>
 
-      <div className="grid items-stretch gap-4 sm:grid-cols-2 xl:grid-cols-5">
-        {kpiItems.map((k) => (
-          <KpiCard key={k.title} {...k} />
+      <div className="grid grid-cols-12 gap-4">
+        {kpis.map((k) => (
+          <div
+            key={k.title}
+            className="col-span-12 sm:col-span-6 lg:col-span-4 xl:col-span-2 rounded-2xl shadow/soft bg-background/60 backdrop-blur border border-white/10 dark:border-white/5 p-4"
+          >
+            <div className="flex items-center gap-3">
+              <div className="rounded-xl bg-primary/90 p-2 text-primary-foreground">
+                {k.icon}
+              </div>
+              <div className="flex flex-col">
+                <span className="text-sm font-medium">{k.title}</span>
+                {transLoading ? (
+                  <SkeletonLine className="mt-1 h-6 w-24" />
+                ) : (
+                  <span className="text-xl font-semibold">
+                    {k.fmt(k.value)}
+                  </span>
+                )}
+              </div>
+            </div>
+          </div>
         ))}
       </div>
 
-      {insights.length > 0 && <InsightBar insights={insights} />}
-
-      <div className="grid gap-4 lg:grid-cols-2 xl:grid-cols-3">
-        <WidgetCard className="glass-card">
-          <div className="mb-3 flex items-center gap-2">
-            <h3 className="text-lg font-semibold">Previsão — 30 dias</h3>
-            <TooltipProvider delayDuration={200}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Info className="size-4 text-zinc-400" />
-                </TooltipTrigger>
-                <TooltipContent>Estimativa simples baseada na média dos últimos dias</TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-          </div>
-          {transacoes.length > 0 ? (
-            <>
-              <ForecastMiniChart data={forecastData} isLoading={transLoading} />
-              <p className="mt-2 text-sm text-zinc-500">
-                Saldo no fim do mês: {formatCurrency(forecastBalance)}
-              </p>
-            </>
-          ) : (
-            <EmptyState title="Sem dados" />
-          )}
-        </WidgetCard>
-        <WidgetCard className="glass-card">
-          <WidgetHeader title="Fluxo de caixa mensal" />
-          {loadingTrans ? (
-            <DailyBars isLoading />
-          ) : uiTransacoes.length > 0 ? (
-            <DailyBars transacoes={uiTransacoes} mes={`${year}-${String(month).padStart(2, "0")}`} />
-          ) : (
-            <EmptyState
-              title="Sem transações"
-              message="Adicione uma transação para ver o fluxo de caixa."
-              action={<Button size="sm" onClick={() => setModalOpen(true)}>Nova transação</Button>}
-            />
-          )}
-          <WidgetFooterAction to="/financas/mensal" label="Ver detalhes" />
-        </WidgetCard>
-
-        <WidgetCard className="glass bg-gradient-to-br from-white/60 to-white/30 dark:from-slate-950/60 dark:to-slate-950/30">
-          <WidgetHeader title="Entradas vs saídas (12 meses)" />
-          {loadingTrans ? (
-            <SkeletonLine className="h-56 w-full" />
-          ) : uiTransacoes.length > 0 ? (
-            <div className="h-56">
-              <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={last12}>
-                  <XAxis dataKey="mes" />
-                  <YAxis />
-                  <RechartsTooltip formatter={(v: number) => formatCurrency(v)} />
-                  <Legend />
-                  <Bar dataKey="entradas" fill="#10b981" />
-                  <Bar dataKey="saidas" fill="#ef4444" />
-                </BarChart>
-              </ResponsiveContainer>
-            </div>
-          ) : (
-            <EmptyState
-              title="Sem dados"
-              message="Adicione transações para visualizar."
-              action={<Button size="sm" onClick={() => setModalOpen(true)}>Nova transação</Button>}
-            />
-          )}
-          <WidgetFooterAction to="/financas/anual" label="Ver detalhes" />
-        </WidgetCard>
-
-        <WidgetCard className="glass bg-gradient-to-br from-white/60 to-white/30 dark:from-slate-950/60 dark:to-slate-950/30">
-          <WidgetHeader title="Despesas por categoria" />
-          {loadingTrans ? (
-            <CategoryDonut isLoading />
-          ) : budgetUsage.length > 0 ? (
-            <CategoryDonut categoriesData={budgetUsage.map(b => ({ category: b.category, value: b.spent }))} />
-          ) : (
-            <EmptyState
-              title="Sem dados"
-              message="Adicione transações para ver categorias."
-              action={<Button size="sm" onClick={() => setModalOpen(true)}>Nova transação</Button>}
-            />
-          )}
-          <WidgetFooterAction to="/financas/mensal" label="Ver detalhes" />
-        </WidgetCard>
-
-        <WidgetCard className="glass bg-gradient-to-br from-white/60 to-white/30 dark:from-slate-950/60 dark:to-slate-950/30">
-          <WidgetHeader title="Contas a vencer" />
-          {upcomingBills.length > 0 ? (
-            <AlertList items={upcomingBills} />
-          ) : (
-            <EmptyState
-              title="Nenhuma conta a vencer"
-              action={<Button size="sm" onClick={() => setModalOpen(true)}>Nova transação</Button>}
-            />
-          )}
-          <WidgetFooterAction to="/financas/mensal" label="Ver detalhes" />
-        </WidgetCard>
-
-        <WidgetCard className="glass-card">
-          <WidgetHeader title="Impacto de desejos comprados" />
-          {wishlistImpact > 0 ? (
-            <p className="px-4 py-6 text-3xl font-semibold">
-              {formatCurrency(wishlistImpact)}
-            </p>
-          ) : (
-            <EmptyState title="Sem desejos comprados" />
-          )}
-        </WidgetCard>
-
-        <RecurrenceList
-          className="glass-card"
-          items={recurrences.map((r) => ({ name: r.description, amount: r.amount }))}
-        />
-
-        <WidgetCard className="glass-card">
-          <WidgetHeader title="Lançamentos recentes" />
-          {uiTransacoes.length > 0 ? (
-            <ul className="divide-y divide-zinc-100/60 dark:divide-zinc-700/60">
-              {uiTransacoes.slice(0, 5).map(t => (
-                <li key={t.id} className="flex justify-between py-2 text-sm">
-                  <span className="flex items-center gap-2 truncate pr-2">
-                    <span className="truncate">{t.description}</span>
-                    {t.origin?.wishlist_item_id && (
-                      <Badge variant="outline">Origem: Desejo</Badge>
-                    )}
-                  </span>
-                  <span
-                    className={
-                      t.type === "income"
-                        ? "text-emerald-600 dark:text-emerald-400"
-                        : "text-rose-600 dark:text-rose-400"
-                    }
-                  >
-                    {formatCurrency(t.value * (t.type === "income" ? 1 : -1))}
-                  </span>
+      <div className="grid grid-cols-12 gap-4">
+        <div className="col-span-12 lg:col-span-6 rounded-2xl shadow/soft bg-background/60 backdrop-blur border border-white/10 dark:border-white/5 p-4">
+          <DailyBars
+            transacoes={filtered}
+            mes={`${year}-${monthStr}`}
+            isLoading={transLoading}
+          />
+        </div>
+        <div className="col-span-12 lg:col-span-6 rounded-2xl shadow/soft bg-background/60 backdrop-blur border border-white/10 dark:border-white/5 p-4">
+          <CategoryDonut categoriesData={categoriesData} isLoading={transLoading} />
+        </div>
+        <div className="col-span-12 lg:col-span-6 rounded-2xl shadow/soft bg-background/60 backdrop-blur border border-white/10 dark:border-white/5 p-4">
+          <h3 className="mb-3 font-medium">Próximos vencimentos</h3>
+          {billsLoading ? (
+            <SkeletonLine className="h-24" />
+          ) : upcomingBills.length ? (
+            <ul className="divide-y divide-white/10 text-sm dark:divide-white/5">
+              {upcomingBills.map((b) => (
+                <li key={b.id} className="flex items-center justify-between py-2">
+                  <span className="truncate pr-2">{b.description}</span>
+                  <span>{new Date(b.due_date).toLocaleDateString("pt-BR")}</span>
+                  <span className="font-medium">{formatCurrency(b.amount)}</span>
                 </li>
               ))}
             </ul>
           ) : (
-            <EmptyState
-              title="Nenhuma transação"
-              action={<Button size="sm" onClick={() => setModalOpen(true)}>Nova transação</Button>}
-            />
+            <EmptyState title="Nenhuma conta" />
           )}
-          <WidgetFooterAction to="/financas/mensal" label="Ver detalhes" />
-        </WidgetCard>
-
-        <WidgetCard className="glass bg-gradient-to-br from-white/60 to-white/30 dark:from-slate-950/60 dark:to-slate-950/30">
-          <WidgetHeader title="Orçamento do mês" />
-          {budgetUsage.length > 0 ? (
-            <ul className="space-y-2">
-              {budgetUsage.slice(0, 5).map(b => (
-                <li key={b.category} className="flex justify-between text-sm">
-                  <span>{b.category}</span>
-                  <span>{formatCurrency(b.spent)}</span>
-                </li>
-              ))}
-            </ul>
+        </div>
+        <div className="col-span-12 rounded-2xl shadow/soft bg-background/60 backdrop-blur border border-white/10 dark:border-white/5 p-4">
+          <h3 className="mb-3 font-medium">Transações recentes</h3>
+          {transLoading ? (
+            <SkeletonLine className="h-40" />
+          ) : recentTransactions.length ? (
+            <TransactionsTable
+              transacoes={recentTransactions}
+              onEdit={() => {}}
+              onDelete={async () => {}}
+            />
           ) : (
-            <EmptyState
-              title="Sem orçamento"
-              action={<Button size="sm" onClick={() => setModalOpen(true)}>Nova transação</Button>}
-            />
+            <EmptyState title="Sem transações" />
           )}
-          <WidgetFooterAction to="/financas/mensal" label="Ver detalhes" />
-        </WidgetCard>
-
-
-        <WidgetCard className="glass bg-gradient-to-br from-white/60 to-white/30 dark:from-slate-950/60 dark:to-slate-950/30">
-          <WidgetHeader title="Alertas" />
-          {upcomingBills.length > 0 ? (
-            <AlertList items={upcomingBills} />
-          ) : (
-            <EmptyState
-              title="Nenhum alerta"
-              action={<Button size="sm" onClick={() => setModalOpen(true)}>Nova transação</Button>}
-            />
-          )}
-          <WidgetFooterAction to="/financas/mensal" label="Ver detalhes" />
-        </WidgetCard>
+        </div>
       </div>
-
-      <ModalTransacao open={modalOpen} onClose={() => setModalOpen(false)} onSubmit={handleSubmit} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- implement FinancasResumo page with filters, KPIs, charts and tables
- expose usePeriod from hooks for simpler imports

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e5e24871483229809ef4f803724b7