### PR TITLE
feat: add overview insight card and drawer components

### DIFF
--- a/src/components/overview/InsightCard.tsx
+++ b/src/components/overview/InsightCard.tsx
@@ -1,0 +1,37 @@
+import type { ReactNode } from "react";
+import { motion } from "framer-motion";
+
+interface InsightCardProps {
+  icon: ReactNode;
+  title: string;
+  subtitle: string;
+  onClick?: () => void;
+}
+
+export default function InsightCard({ icon, title, subtitle, onClick }: InsightCardProps) {
+  return (
+    <motion.div
+      role="button"
+      aria-haspopup="dialog"
+      tabIndex={0}
+      initial={{ opacity: 0, scale: 0.95 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.2 }}
+      onClick={onClick}
+      onKeyDown={(e) => {
+        if (onClick && (e.key === "Enter" || e.key === " ")) {
+          e.preventDefault();
+          onClick();
+        }
+      }}
+      className="rounded-2xl bg-background/40 backdrop-blur border border-white/10 shadow-sm hover:shadow-lg transition-shadow cursor-pointer p-4 flex items-center gap-3"
+    >
+      <span className="text-2xl">{icon}</span>
+      <div className="flex flex-col">
+        <span className="font-medium leading-none">{title}</span>
+        <span className="text-sm text-muted-foreground">{subtitle}</span>
+      </div>
+    </motion.div>
+  );
+}
+

--- a/src/components/overview/InsightDrawer.tsx
+++ b/src/components/overview/InsightDrawer.tsx
@@ -1,0 +1,43 @@
+import type { ReactNode } from "react";
+import * as Dialog from "@radix-ui/react-dialog";
+import { X } from "lucide-react";
+
+interface InsightDrawerProps {
+  title: string;
+  description?: string;
+  children: ReactNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export default function InsightDrawer({
+  title,
+  description,
+  children,
+  open,
+  onOpenChange,
+}: InsightDrawerProps) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/40 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in-0 data-[state=closed]:fade-out-0" />
+        <Dialog.Content className="fixed right-0 top-0 z-50 h-full w-80 sm:w-96 bg-background p-6 border-l border-white/10 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right">
+          <div className="space-y-2">
+            <Dialog.Title className="text-lg font-semibold">{title}</Dialog.Title>
+            {description && (
+              <Dialog.Description className="text-sm text-muted-foreground">
+                {description}
+              </Dialog.Description>
+            )}
+          </div>
+          <div className="mt-4 overflow-y-auto">{children}</div>
+          <Dialog.Close className="absolute top-4 right-4 rounded-sm opacity-70 hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2">
+            <X className="h-4 w-4" />
+            <span className="sr-only">Close</span>
+          </Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add glassmorphic InsightCard with motion animation and accessibility
- implement InsightDrawer using Radix Dialog

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e68e60ccc8322b5e693c55d541b04