### PR TITLE
feat: add moving average forecast

### DIFF
--- a/src/utils/forecast.test.ts
+++ b/src/utils/forecast.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+
+import { movingAverage, forecast30d } from './forecast';
+
+describe('movingAverage', () => {
+  it('computes averages with default window', () => {
+    const result = movingAverage([1, 2, 3, 4, 5, 6, 7]);
+    expect(result).toEqual([1, 1.5, 2, 2.5, 3, 3.5, 4]);
+  });
+});
+
+describe('forecast30d', () => {
+  it('forecasts constant trend using moving average', () => {
+    const transactions = Array.from({ length: 7 }, (_, i) => ({
+      id: i + 1,
+      date: `2025-01-${(i + 1).toString().padStart(2, '0')}`,
+      description: '',
+      value: 10,
+      type: 'income' as const,
+    }));
+    const { series, total } = forecast30d(transactions);
+    expect(series).toHaveLength(30);
+    expect(series.every(s => s.value === 10)).toBe(true);
+    expect(total).toBe(300);
+  });
+});

--- a/src/utils/forecast.ts
+++ b/src/utils/forecast.ts
@@ -1,3 +1,7 @@
+import dayjs from "dayjs";
+
+import type { UITransaction } from "@/components/TransactionsTable";
+
 /**
  * Simple moving average for a series of numbers.
  */
@@ -7,6 +11,24 @@ export function simpleMovingAverage(points: number[], window: number) {
     const start = Math.max(0, i - window + 1);
     const slice = points.slice(start, i + 1);
     const avg = slice.reduce((s, v) => s + v, 0) / (slice.length || 1);
+    out.push(avg);
+  }
+  return out;
+}
+
+/**
+ * Moving average with a configurable window (defaults to 7).
+ *
+ * Unlike `simpleMovingAverage`, this helper provides a default
+ * window size so callers don't need to specify one for common
+ * use-cases.
+ */
+export function movingAverage(values: number[], window = 7) {
+  const out: number[] = [];
+  for (let i = 0; i < values.length; i++) {
+    const start = Math.max(0, i - window + 1);
+    const slice = values.slice(start, i + 1);
+    const avg = slice.reduce((sum, v) => sum + v, 0) / (slice.length || 1);
     out.push(avg);
   }
   return out;
@@ -34,4 +56,55 @@ export function priceDropLikely(history: number[]) {
   const last = history[history.length - 1];
   const prev = ema[ema.length - 1];
   return last < prev;
+}
+
+
+/**
+ * Generates a 30 day forecast based on historical transactions.
+ *
+ * The forecast uses the moving average of the latest values and
+ * iteratively projects the next 30 days.
+ */
+export function forecast30d(transactions: UITransaction[]) {
+  if (!Array.isArray(transactions)) return { series: [], total: 0 };
+
+  // group transactions by date (YYYY-MM-DD) and compute net daily value
+  const daily = new Map<string, number>();
+  for (const t of transactions) {
+    const value = t.type === "income" ? t.value : -t.value;
+    daily.set(t.date, (daily.get(t.date) || 0) + value);
+  }
+
+  const dates = Array.from(daily.keys()).sort();
+  if (dates.length === 0) {
+    const start = dayjs();
+    const series = Array.from({ length: 30 }, (_, i) => ({
+      date: start.add(i + 1, "day").format("YYYY-MM-DD"),
+      value: 0,
+    }));
+    return { series, total: 0 };
+  }
+
+  // fill missing days with 0 to maintain continuity
+  const startDate = dayjs(dates[0]);
+  const endDate = dayjs(dates[dates.length - 1]);
+  const values: number[] = [];
+  for (let d = startDate; !d.isAfter(endDate); d = d.add(1, "day")) {
+    const key = d.format("YYYY-MM-DD");
+    values.push(daily.get(key) || 0);
+  }
+
+  // forecast next 30 days iteratively using moving average
+  const series: { date: string; value: number }[] = [];
+  let lastDate = endDate;
+  for (let i = 0; i < 30; i++) {
+    const ma = movingAverage(values);
+    const next = ma[ma.length - 1] || 0;
+    lastDate = lastDate.add(1, "day");
+    series.push({ date: lastDate.format("YYYY-MM-DD"), value: next });
+    values.push(next);
+  }
+
+  const total = series.reduce((sum, s) => sum + s.value, 0);
+  return { series, total };
 }


### PR DESCRIPTION
## Summary
- add generic `movingAverage` helper
- implement `forecast30d` for 30 day transaction forecasts
- cover moving average utilities with unit tests

## Testing
- `npx vitest run src/utils/forecast.test.ts`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e68f22aa083229fc5cc8445ca447f