### PR TITLE
feat: add menu suggestions component

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -10,6 +10,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "./ui/dropdown-menu";
+import MenuSuggestions from "./layout/MenuSuggestions";
 
 import {
   Home,
@@ -135,28 +136,31 @@ export function Sidebar() {
         </NavItem>
       </nav>
 
-      <div className="mx-3 mb-3 mt-auto rounded-xl border border-white/10 p-3 bg-background/40 backdrop-blur">
-        <div className="flex items-center gap-3">
-          <div className="h-8 w-8 rounded-full bg-emerald-600 text-white grid place-items-center text-sm">
-            {initials}
-          </div>
-          <div className="text-sm">
-            <div className="font-medium">{displayName}</div>
-            <div className="text-muted-foreground text-xs">online</div>
-          </div>
-          <div className="ms-auto">
-            <DropdownMenu>
-              <DropdownMenuTrigger className="rounded-lg p-2 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50">
-                <ChevronDown className="h-4 w-4" />
-              </DropdownMenuTrigger>
-              <DropdownMenuContent align="end">
-                <DropdownMenuItem asChild>
-                  <a href="/perfil">Perfil</a>
-                </DropdownMenuItem>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={signOut}>Sair</DropdownMenuItem>
-              </DropdownMenuContent>
-            </DropdownMenu>
+      <div className="mt-auto">
+        <MenuSuggestions />
+        <div className="mx-3 mb-3 mt-3 rounded-xl border border-white/10 p-3 bg-background/40 backdrop-blur">
+          <div className="flex items-center gap-3">
+            <div className="h-8 w-8 rounded-full bg-emerald-600 text-white grid place-items-center text-sm">
+              {initials}
+            </div>
+            <div className="text-sm">
+              <div className="font-medium">{displayName}</div>
+              <div className="text-muted-foreground text-xs">online</div>
+            </div>
+            <div className="ms-auto">
+              <DropdownMenu>
+                <DropdownMenuTrigger className="rounded-lg p-2 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50">
+                  <ChevronDown className="h-4 w-4" />
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem asChild>
+                    <a href="/perfil">Perfil</a>
+                  </DropdownMenuItem>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onClick={signOut}>Sair</DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/layout/MenuSuggestions.tsx
+++ b/src/components/layout/MenuSuggestions.tsx
@@ -1,0 +1,50 @@
+import { Link } from "react-router-dom";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { Home, Target, TrendingUp } from "@/components/icons";
+
+interface SuggestionItem {
+  label: string;
+  to: string;
+  icon: React.ComponentType<{ className?: string }>;
+}
+
+const mockSuggestions: SuggestionItem[] = [
+  { label: "Visão geral", to: "/dashboard", icon: Home },
+  { label: "Investimentos", to: "/investimentos", icon: TrendingUp },
+  { label: "Metas", to: "/metas", icon: Target },
+];
+
+export default function MenuSuggestions({ compact = false }: { compact?: boolean }) {
+  return (
+    <div className="mx-3 mb-3 space-y-1">
+      {mockSuggestions.map(({ label, to, icon: Icon }) => {
+        const content = (
+          <Link
+            to={to}
+            className="flex items-center gap-3 rounded-xl px-3 py-2 text-foreground transition hover:bg-background/40 hover:backdrop-blur focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500/50"
+          >
+            <Icon className="h-5 w-5 opacity-90" />
+            {!compact && <span className="text-sm">{label}</span>}
+          </Link>
+        );
+
+        return compact ? (
+          <TooltipProvider delayDuration={200} key={to}>
+            <Tooltip>
+              <TooltipTrigger asChild>{content}</TooltipTrigger>
+              <TooltipContent side="right">{label}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        ) : (
+          <div key={to}>{content}</div>
+        );
+      })}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add mock `MenuSuggestions` component supporting compact mode
- render suggested links in sidebar footer

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e6fd7e93c832287c48789d2d0558b