### PR TITLE
Remove unused Hero and QuickLinks imports

### DIFF
--- a/src/pages/HomeOverview.tsx
+++ b/src/pages/HomeOverview.tsx
@@ -12,8 +12,6 @@ import {
   Plane,
 } from "lucide-react";
 
-import Hero from "@/components/dashboard/Hero";
-import QuickLinks, { type QuickLink } from "@/components/overview/QuickLinks";
 import PageHeader from "@/components/PageHeader";
 import KPIStrip, { type KpiItem } from "@/components/dashboard/KPIStrip";
 import ForecastChart, { type FluxoItem } from "@/components/dashboard/ForecastChart";


### PR DESCRIPTION
## Summary
- remove unused `Hero` and `QuickLinks` imports from the HomeOverview page

## Testing
- `npm_config_http_proxy="" npm_config_https_proxy="" npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_689e6fde24388322b5eb39ce28508c59