### PR TITLE
feat: update dashboard routing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -82,10 +82,10 @@ function AppRoutes() {
       <Suspense fallback={<RouteLoader />}>
 
         <Routes>
-            {/* Home overview */}
-            <Route path="/homeoverview" element={<HomeOverview />} />
-            <Route path="/home" element={<Navigate to="/homeoverview" replace />} />
-            <Route path="/" element={<Navigate to="/homeoverview" replace />} />
+            {/* Dashboard */}
+            <Route path="/dashboard" element={<HomeOverview />} />
+            <Route path="/home" element={<Navigate to="/dashboard" replace />} />
+            <Route path="/" element={<Navigate to="/dashboard" replace />} />
 
             {/* Finanças */}
             <Route path="/financas/resumo" element={<FinancasResumo />} />

--- a/src/components/AppHotkeys.tsx
+++ b/src/components/AppHotkeys.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { toast } from "sonner";
 
 const map: Record<string, string> = {
-  d: "/homeoverview",
+  d: "/dashboard",
   f: "/financas/mensal",
   i: "/investimentos/resumo",
   m: "/metas",

--- a/src/components/layout/NavMenu.tsx
+++ b/src/components/layout/NavMenu.tsx
@@ -31,7 +31,7 @@ export interface NavMenuItem {
 }
 
 export const defaultNavItems: NavMenuItem[] = [
-  { label: "Visão geral", icon: LayoutDashboard, to: "/homeoverview" },
+  { label: "Visão geral", icon: LayoutDashboard, to: "/dashboard" },
   {
     label: "Finanças",
     icon: WalletCards,

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -27,7 +27,7 @@ interface NavItem {
 }
 
 const items: NavItem[] = [
-  { label: "Visão Geral", to: "/homeoverview", icon: LayoutDashboard },
+  { label: "Visão Geral", to: "/dashboard", icon: LayoutDashboard },
   { label: "Investimentos", to: "/investimentos/resumo", icon: TrendingUp },
   { label: "Metas e Projetos", to: "/metas", icon: Target },
   { label: "Milhas", to: "/milhas", icon: Plane },

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -17,7 +17,7 @@ export default function Topbar() {
     <header className="topbar-glass sticky top-0 z-50 border-b border-white/10 bg-gradient-to-r from-emerald-600/80 to-teal-600/80 backdrop-blur">
       <div className="mx-auto flex h-16 items-center px-4">
         <NavLink
-          to="/homeoverview"
+          to="/dashboard"
           className="flex items-center text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-white/50 rounded"
         >
           <Logo size="lg" />

--- a/src/routes/nav.ts
+++ b/src/routes/nav.ts
@@ -44,7 +44,7 @@ export const navGroups: NavGroup[] = [
 ];
 
 export const navRoutes: NavRoute[] = [
-  { label: 'Visão geral', to: '/homeoverview', variant: 'pill' },
+  { label: 'Visão geral', to: '/dashboard', variant: 'pill' },
   { label: 'Finanças', to: '/financas/resumo' },
   { label: 'Investimentos', to: '/investimentos/resumo' },
   { label: 'Metas & Projetos', to: '/metas' },
@@ -55,7 +55,7 @@ export const navRoutes: NavRoute[] = [
 
 export const dashboardNavItem: NavItem = {
   label: 'Visão geral',
-  to: '/homeoverview',
+  to: '/dashboard',
 };
 
 export function getNavItem(pathname: string): NavItem | null {


### PR DESCRIPTION
## Summary
- replace `/homeoverview` with `/dashboard`
- redirect `/` and `/home` to `/dashboard`
- align navigation, hotkeys, and menus with `/dashboard`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e737717cc8322bc1047964fb88e13