### PR TITLE
refactor: centralize toast rendering

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,7 @@
 import { Suspense, lazy } from 'react';
 import { Navigate, Route, BrowserRouter as Router, Routes } from 'react-router-dom';
-// Use o Toaster direto do sonner para ter 'richColors' tipado
-import { Toaster } from 'sonner';
 
+import { Toaster } from '@/components/ui/Toasts';
 import AppHotkeys from '@/components/AppHotkeys';
 import RouteLoader from '@/components/RouteLoader';
 import AppShell from '@/components/AppShell';
@@ -61,7 +60,7 @@ function AppRoutes() {
   if (!user)
     return (
       <Suspense fallback={<RouteLoader />}>
-        <Toaster richColors position="top-right" />
+        <Toaster position="top-right" />
         <Routes>
           {/* rotas públicas para e-mails do Supabase */}
           <Route path="/confirm" element={<Confirm />} />
@@ -78,6 +77,7 @@ function AppRoutes() {
     <AppShell topbar={<Topbar />}>
       {/* ⬇️ Atalhos globais (g d, g f, g i, g m, g c, Shift+/? para ajuda) */}
       <AppHotkeys />
+      <Toaster position="top-right" />
 
       <Suspense fallback={<RouteLoader />}>
 

--- a/src/components/AppHotkeys.tsx
+++ b/src/components/AppHotkeys.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { useNavigate } from "react-router-dom";
-import { toast } from "sonner";
+
+import { toast } from "@/components/ui/Toasts";
 
 const map: Record<string, string> = {
   d: "/homeoverview",

--- a/src/components/AppTopbar.tsx
+++ b/src/components/AppTopbar.tsx
@@ -1,5 +1,4 @@
 import { NavLink } from 'react-router-dom';
-import { Toaster } from 'sonner';
 
 import AvatarMenu from './layout/AvatarMenu';
 import NavItem from './layout/NavItem';
@@ -43,7 +42,6 @@ export default function AppTopbar() {
           <AvatarMenu />
         </div>
       </div>
-      <Toaster richColors position="top-right" />
     </header>
   );
 }

--- a/src/components/CategoryPicker.tsx
+++ b/src/components/CategoryPicker.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState, useId } from "react";
 import { Plus, Pencil, Trash2, X } from "lucide-react";
-import { toast } from "sonner";
 
+import { toast } from "@/components/ui/Toasts";
 import {
   Select,
   SelectContent,

--- a/src/components/ModalCartao.tsx
+++ b/src/components/ModalCartao.tsx
@@ -1,8 +1,6 @@
-
-
 import { useMemo, useState } from "react";
-import { toast } from "sonner";
 
+import { toast } from "@/components/ui/Toasts";
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";

--- a/src/components/ModalTransacao.tsx
+++ b/src/components/ModalTransacao.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { toast } from 'sonner';
 import dayjs from 'dayjs';
 
+import { toast } from '@/components/ui/Toasts';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogFooter } from '@/components/ui/dialog';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';

--- a/src/components/SourcePicker.tsx
+++ b/src/components/SourcePicker.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState, useId } from "react";
 import { CreditCard, Plus } from "lucide-react";
-import { toast } from "sonner";
 
+import { toast } from "@/components/ui/Toasts";
 import { Wallet } from "@/components/icons";
 import { useAccounts } from "@/hooks/useAccounts";
 import { useCreditCards, cycleFor as cardCycleFor } from "@/hooks/useCreditCards";

--- a/src/components/TransactionsTable.tsx
+++ b/src/components/TransactionsTable.tsx
@@ -14,8 +14,8 @@ import {
   Plus,
 } from "lucide-react";
 import dayjs from "dayjs";
-import { toast } from "sonner";
 
+import { toast } from "@/components/ui/Toasts";
 import { Wallet } from "@/components/icons";
 import { exportTransactionsPDF } from "@/utils/pdf";
 import {

--- a/src/components/layout/Topbar.tsx
+++ b/src/components/layout/Topbar.tsx
@@ -1,5 +1,4 @@
 import { NavLink } from 'react-router-dom';
-import { Toaster } from 'sonner';
 
 import AvatarMenu from './AvatarMenu';
 import NavItem from './NavItem';
@@ -44,7 +43,6 @@ export default function Topbar() {
           <AvatarMenu />
         </div>
       </div>
-      <Toaster richColors position="top-right" />
     </header>
   );
 }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,6 @@ import '@fontsource-variable/inter'
 
 import App from '@/App'
 import AppErrorBoundary from '@/components/AppErrorBoundary'
-import { Toaster } from '@/components/ui/Toasts'
 import '@/index.css'
 import '@/styles/glass.css'
 
@@ -17,10 +16,7 @@ if ('serviceWorker' in navigator && import.meta.env.PROD) {
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <AppErrorBoundary>
-      <>
-        <App />
-        <Toaster />
-      </>
+      <App />
     </AppErrorBoundary>
   </StrictMode>
 );

--- a/src/pages/CarteiraBolsa.tsx
+++ b/src/pages/CarteiraBolsa.tsx
@@ -1,8 +1,8 @@
 // src/pages/CarteiraBolsa.tsx
 import { useMemo, useState } from "react";
-import { toast } from "sonner";
 import { Plus, MoreHorizontal, Pencil, Trash2, CandlestickChart } from "lucide-react";
 
+import { toast } from "@/components/ui/Toasts";
 import { useInvestments } from "@/hooks/useInvestments";
 import ModalInvest from "@/components/ModalInvest";
 import PageHeader from "@/components/PageHeader";

--- a/src/pages/CarteiraCripto.tsx
+++ b/src/pages/CarteiraCripto.tsx
@@ -1,8 +1,8 @@
 // src/pages/CarteiraCripto.tsx
 import { useMemo, useState } from "react";
-import { toast } from "sonner";
 import { Plus, MoreHorizontal, Pencil, Trash2, Coins } from "lucide-react";
 
+import { toast } from "@/components/ui/Toasts";
 import { useInvestments } from "@/hooks/useInvestments";
 import ModalInvest from "@/components/ModalInvest";
 import PageHeader from "@/components/PageHeader";

--- a/src/pages/CarteiraFIIs.tsx
+++ b/src/pages/CarteiraFIIs.tsx
@@ -1,8 +1,8 @@
 // src/pages/CarteiraFIIs.tsx
 import { useMemo, useState } from "react";
-import { toast } from "sonner";
 import { Plus, MoreHorizontal, Pencil, Trash2, Building2 } from "lucide-react";
 
+import { toast } from "@/components/ui/Toasts";
 import { useInvestments } from "@/hooks/useInvestments";
 import ModalInvest from "@/components/ModalInvest";
 import PageHeader from "@/components/PageHeader";

--- a/src/pages/CarteiraRendaFixa.tsx
+++ b/src/pages/CarteiraRendaFixa.tsx
@@ -1,8 +1,8 @@
 // src/pages/CarteiraRendaFixa.tsx
 import { useMemo, useState } from "react";
-import { toast } from "sonner";
 import { Plus, MoreHorizontal, Pencil, Trash2, Coins } from "lucide-react";
 
+import { toast } from "@/components/ui/Toasts";
 import { useInvestments } from "@/hooks/useInvestments";
 import ModalInvest from "@/components/ModalInvest";
 import PageHeader from "@/components/PageHeader";

--- a/src/pages/CarteiraTipo.tsx
+++ b/src/pages/CarteiraTipo.tsx
@@ -1,8 +1,8 @@
 // src/pages/CarteiraTipo.tsx
 import { useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
 import { Plus, MoreHorizontal, Pencil, Trash2, Coins } from "lucide-react";
 
+import { toast } from "@/components/ui/Toasts";
 import { supabase } from "@/lib/supabaseClient";
 import { useAuth } from "@/contexts/AuthContext";
 import PageHeader from "@/components/PageHeader";

--- a/src/pages/Confirm.tsx
+++ b/src/pages/Confirm.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { toast } from "sonner";
 
+import { toast } from "@/components/ui/Toasts";
 import { supabase } from "@/lib/supabaseClient";
 
 export default function Confirm() {

--- a/src/pages/FinancasMensal.tsx
+++ b/src/pages/FinancasMensal.tsx
@@ -2,8 +2,8 @@ import dayjs from 'dayjs';
 import { CalendarRange, Clock, Coins, Copy, Download, Plus, Search, TrendingDown, TrendingUp } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom';
-import { toast } from 'sonner';
 
+import { toast } from '@/components/ui/Toasts';
 import CategoryDonut from "@/components/charts/CategoryDonut";
 import DailyBars from "@/components/charts/DailyBars";
 import { ModalTransacao, type BaseData } from "@/components/ModalTransacao";

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,8 +1,8 @@
 // src/pages/Login.tsx
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { Link, useLocation, useNavigate } from 'react-router-dom';
-import { toast } from 'sonner';
 
+import { toast } from '@/components/ui/Toasts';
 import { useAuth } from '@/contexts/AuthContext';
 
 /**

--- a/src/pages/Metas.tsx
+++ b/src/pages/Metas.tsx
@@ -1,6 +1,5 @@
 // src/pages/Metas.tsx
 import { useEffect, useMemo, useState } from "react";
-import { toast } from "sonner";
 import {
   Plus,
   CalendarDays,
@@ -16,6 +15,7 @@ import {
   Search,
 } from "lucide-react";
 
+import { toast } from "@/components/ui/Toasts";
 import { Target } from "@/components/icons";
 import { supabase } from "@/lib/supabaseClient";
 import { useAuth } from "@/contexts/AuthContext";

--- a/src/pages/MilhasLivelo.tsx
+++ b/src/pages/MilhasLivelo.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useState, type CSSProperties } from 'react';
 import dayjs from 'dayjs';
-import { toast } from 'sonner';
 import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
 
+import { toast } from '@/components/ui/Toasts';
 import MilesHeader, { type MilesProgram } from '@/components/miles/MilesHeader';
 import { BRANDS } from '@/components/miles/brandConfig';
 import { MotionCard } from '@/components/ui/MotionCard';

--- a/src/pages/ResetPassword.tsx
+++ b/src/pages/ResetPassword.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { toast } from "sonner";
 
+import { toast } from "@/components/ui/Toasts";
 import { supabase } from "@/lib/supabaseClient";
 
 export default function ResetPassword() {


### PR DESCRIPTION
## Summary
- centralize toast and toaster imports through `@/components/ui/Toasts`
- render a single Toaster in each AppRoutes branch
- remove redundant Toaster instances across the app

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e737b7b9483229bf2ecfb35869fa1