### PR TITLE
refactor: export PageHeader types separately

### DIFF
--- a/src/components/PageHeader.tsx
+++ b/src/components/PageHeader.tsx
@@ -4,9 +4,9 @@ import { motion } from 'framer-motion'
 
 import { cn } from "@/lib/utils";
 
-export type Breadcrumb = { label: string; href?: string };
+type Breadcrumb = { label: string; href?: string };
 
-export type PageHeaderProps = {
+type PageHeaderProps = {
   title: string;
   subtitle?: string;
   icon?: ReactNode;
@@ -70,4 +70,4 @@ const PageHeader = (props: PageHeaderProps) => {
 };
 
 export default PageHeader;
-// Tipos já exportados junto do componente; evitar export duplicado
+export type { Breadcrumb, PageHeaderProps };


### PR DESCRIPTION
## Summary
- refactor PageHeader type declarations to use local types and re-export

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_689e737caf7c83228492057733e6c493