### PR TITLE
chore: use project build for type checking

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc -b",
     "format": "prettier --write .",
     "prepare": "husky",
     "codemod:imports": "tsx scripts/codemod-rewrite-imports.ts",


### PR DESCRIPTION
## Summary
- use TypeScript project build for the `typecheck` script

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run typecheck` *(fails: TypeScript errors)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e738201cc832284c48c3db8cfc04f